### PR TITLE
Fix language filters

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -47,7 +47,7 @@ export const languages = [
   { code: 'en', name: 'English', lang: 'English' },
   { code: 'jp', name: 'Japanese', lang: '日本語' },
   { code: 'es', name: 'Spanish', lang: 'Español' },
-  { code: 'id', name: 'Indonesian', lang: 'bahasa Indonesia' },
+  { code: 'id', name: 'Indonesian', lang: 'Bahasa Indonesia' },
   { code: 'kr', name: 'Korean', lang: '한국' },
   { code: 'ch', name: 'Chinese', lang: '中文' },
   { code: 'ru', name: 'Russian', lang: 'русский' },
@@ -65,4 +65,4 @@ function createLangSelectionName(lang) {
 }
 
 languages.forEach(i => languageConversionTable[createLangSelectionName(i)] = i);
-languages.forEach(lang => languageNameCode[lang.name] = lang);
+languages.forEach(lang => languageNameCode[lang.lang] = lang);


### PR DESCRIPTION
Settings was saving `lang.lang` while `languageNameCode` stored `lang.name`, causing TypeError for language filters other than English, since both values are the same for English.

Also fixes capitalization on `Bahasa Indonesia`.