### PR TITLE
Redraw settings slider on resize

### DIFF
--- a/src/components/Options.svelte
+++ b/src/components/Options.svelte
@@ -2,12 +2,13 @@
   import { MaterialApp } from 'svelte-materialify/src';
   import Settings from './Settings.svelte';
   export let isStandalone = false;
+  export let isResizing = false;
 </script>
 
 <MaterialApp theme="dark">
   <div class="wrapper">
     <div class="app">
-      <Settings {isStandalone} />
+      <Settings {isStandalone} {isResizing} />
     </div>
     <slot />
   </div>

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -26,7 +26,7 @@
   </div>
   <Wrapper {isResizing}>
     {#if settingsOpen}
-      <Options {isStandalone} />
+      <Options {isStandalone} {isResizing} />
     {/if}
     <div style="display: {settingsOpen ? 'none' : 'block'};">
       <MessageDisplay

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { beforeUpdate, afterUpdate } from 'svelte';
+  import { beforeUpdate, afterUpdate, onMount, onDestroy } from 'svelte';
   import { Tabs, Tab, TabContent, MaterialApp } from 'svelte-materialify/src';
   import UISettings from './settings/UISettings.svelte';
   import FilterSettings from './settings/FilterSettings.svelte';
@@ -44,7 +44,12 @@
     }
     callRedrawSlider = false;
   });
-  window.onresize = redrawSlider;
+  onMount(() => {
+    window.onresize = redrawSlider;
+  });
+  onDestroy(() => {
+    window.onresize = null;
+  });
 </script>
 
 <MaterialApp theme="dark">

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -13,8 +13,9 @@
   ];
 
   function redrawSlider() {
-    const sliderElement = document.querySelector('.s-tab-slider');
-    const activeTab = document.querySelector('.s-tab.s-slide-item.active');
+    const sliderElement = document.querySelector('.ltl-settings-slider');
+    const activeTab = 
+      document.querySelector('.ltl-settings-tabs .s-tab.s-slide-item.active');
     if (
       !sliderElement || 
       !activeTab || 
@@ -45,7 +46,13 @@
 <MaterialApp theme="dark">
   <div style="display: flex; align-items: center; justify-content: center;">
     <div style="max-width: calc(min(500px, 100%)); width: 100%;">
-      <Tabs grow fixedTabs showArrows={false}>
+      <Tabs 
+        grow 
+        fixedTabs 
+        showArrows={false} 
+        class="ltl-settings-tabs" 
+        sliderClass="ltl-settings-slider"
+      >
         <div slot="tabs">
           {#each settings as { name }}
             <Tab>{name}</Tab>

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -9,7 +9,7 @@
 
   const settings = [
     { name: 'Interface', component: UISettings },
-    { name: 'Filters', component: FilterSettings }
+    { name: 'Filters', component: FilterSettings },
   ];
 
   let wrapper = null;
@@ -44,13 +44,9 @@
     }
     callRedrawSlider = false;
   });
-  onMount(() => {
-    window.addEventListener('resize', redrawSlider);
-  });
-  onDestroy(() => {
-    window.removeEventListener('resize', redrawSlider);
-  });
 </script>
+
+<svelte:window on:resize={redrawSlider} />
 
 <MaterialApp theme="dark">
   <div

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -9,18 +9,22 @@
 
   const settings = [
     { name: 'Interface', component: UISettings },
-    { name: 'Filters', component: FilterSettings }
+    { name: 'Filters', component: FilterSettings },
   ];
 
+  let wrapper = null;
   function redrawSlider() {
-    const sliderElement = document.querySelector('.ltl-settings-slider');
-    const activeTab = 
-      document.querySelector('.ltl-settings-tabs .s-tab.s-slide-item.active');
+    const sliderElement = wrapper.querySelector('.ltl-settings-slider');
+    const activeTab = wrapper.querySelector(
+      '.ltl-settings-tabs .s-tab.s-slide-item.active'
+    );
     if (
-      !sliderElement || 
-      !activeTab || 
-      !sliderElement.offsetParent || 
-      !activeTab.offsetParent) return;
+      !sliderElement ||
+      !activeTab ||
+      !sliderElement.offsetParent ||
+      !activeTab.offsetParent
+    )
+      return;
 
     sliderElement.style.left = `${activeTab.offsetLeft}px`;
     sliderElement.style.width = `${activeTab.offsetWidth}px`;
@@ -36,7 +40,7 @@
   });
   afterUpdate(() => {
     if (callRedrawSlider) {
-      redrawSlider()
+      redrawSlider();
     }
     callRedrawSlider = false;
   });
@@ -44,13 +48,16 @@
 </script>
 
 <MaterialApp theme="dark">
-  <div style="display: flex; align-items: center; justify-content: center;">
+  <div
+    style="display: flex; align-items: center; justify-content: center;"
+    bind:this={wrapper}
+  >
     <div style="max-width: calc(min(500px, 100%)); width: 100%;">
-      <Tabs 
-        grow 
-        fixedTabs 
-        showArrows={false} 
-        class="ltl-settings-tabs" 
+      <Tabs
+        grow
+        fixedTabs
+        showArrows={false}
+        class="ltl-settings-tabs"
         sliderClass="ltl-settings-slider"
       >
         <div slot="tabs">

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { beforeUpdate, afterUpdate } from 'svelte';
+  import { beforeUpdate, afterUpdate, onMount, onDestroy } from 'svelte';
   import { Tabs, Tab, TabContent, MaterialApp } from 'svelte-materialify/src';
   import UISettings from './settings/UISettings.svelte';
   import FilterSettings from './settings/FilterSettings.svelte';
@@ -9,7 +9,7 @@
 
   const settings = [
     { name: 'Interface', component: UISettings },
-    { name: 'Filters', component: FilterSettings },
+    { name: 'Filters', component: FilterSettings }
   ];
 
   let wrapper = null;
@@ -44,7 +44,12 @@
     }
     callRedrawSlider = false;
   });
-  window.onresize = redrawSlider;
+  onMount(() => {
+    window.addEventListener('resize', redrawSlider);
+  });
+  onDestroy(() => {
+    window.removeEventListener('resize', redrawSlider);
+  });
 </script>
 
 <MaterialApp theme="dark">

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -1,14 +1,45 @@
 <script>
+  import { beforeUpdate, afterUpdate } from 'svelte';
   import { Tabs, Tab, TabContent, MaterialApp } from 'svelte-materialify/src';
   import UISettings from './settings/UISettings.svelte';
   import FilterSettings from './settings/FilterSettings.svelte';
 
   export let isStandalone = false;
+  export let isResizing = false;
 
   const settings = [
     { name: 'Interface', component: UISettings },
     { name: 'Filters', component: FilterSettings }
   ];
+
+  function redrawSlider() {
+    const sliderElement = document.querySelector('.s-tab-slider');
+    const activeTab = document.querySelector('.s-tab.s-slide-item.active');
+    if (
+      !sliderElement || 
+      !activeTab || 
+      !sliderElement.offsetParent || 
+      !activeTab.offsetParent) return;
+
+    sliderElement.style.left = `${activeTab.offsetLeft}px`;
+    sliderElement.style.width = `${activeTab.offsetWidth}px`;
+  }
+
+  let callRedrawSlider = false;
+  let wasResizing = false;
+  $: wasResizing = !isResizing;
+  beforeUpdate(() => {
+    if (wasResizing) {
+      callRedrawSlider = true;
+    }
+  });
+  afterUpdate(() => {
+    if (callRedrawSlider) {
+      redrawSlider()
+    }
+    callRedrawSlider = false;
+  });
+  window.onresize = redrawSlider;
 </script>
 
 <MaterialApp theme="dark">

--- a/src/components/options/MultiDropdown.svelte
+++ b/src/components/options/MultiDropdown.svelte
@@ -7,13 +7,13 @@
     Icon,
     Menu,
     TextField,
-    ListItem
+    ListItem,
   } from 'svelte-materialify/src';
 
   export let name = '';
   export let store = null; // LookupStore
   export let getDisplayName = (key, value) => `${key}` || value;
-  export let getBool = key => store.get(key);
+  export let getBool = (key) => store.get(key);
   export let setBool = (key, val) => store.set(key, val);
 
   let field = null;

--- a/src/components/options/Slider.svelte
+++ b/src/components/options/Slider.svelte
@@ -29,10 +29,6 @@
   }
 
   $: if (wrapper && thumb && scaledBack != null) setThumb();
-  onMount(async () => {
-    await tick();
-    setThumb();
-  });
 
   function tipCallback(handle) {
     const tip = wrapper.querySelector('.s-slider__tooltip');
@@ -43,6 +39,7 @@
     }
   }
 
+  let mutationObserver;
   $: if (wrapper) {
     const handle = wrapper.querySelector('.s-slider__handle-lower');
     if (handle) {
@@ -53,11 +50,20 @@
           }
         });
       };
-      const mutationObserver = new MutationObserver(callback);
+      mutationObserver = new MutationObserver(callback);
       mutationObserver.observe(handle, { attributes: true });
       tipCallback(handle);
     }
   }
+
+  onMount(async () => {
+    await tick();
+    setThumb();
+  });
+
+  onDestroy(() => {
+    if (mutationObserver) mutationObserver.disconnect();
+  });
 </script>
 
 <div bind:this={wrapper}>

--- a/src/components/options/Slider.svelte
+++ b/src/components/options/Slider.svelte
@@ -2,7 +2,7 @@
   import { Button, Icon, Slider } from 'svelte-materialify/src';
   import { mdiRestore } from '@mdi/js';
   import { Browser, BROWSER } from '../../js/constants.js';
-  import { onMount, tick } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
 
   export let min = BROWSER == Browser.ANDROID ? 0.25 : 0.5;
   export let max = BROWSER == Browser.ANDROID ? 1.5 : 2;


### PR DESCRIPTION
Fixes visual bug where settings slider stays at the same position/width when the panel/window is resized.

Based on https://github.com/TheComputerM/svelte-materialify/blob/09eb0efb34941565f409757764be1c85519ffced/packages/svelte-materialify/src/components/Tabs/Tabs.svelte#L43.

Probably should be implemented upstream, but the lib is deprecating so ¯\\\_(ツ)\_/¯