### PR TITLE
Include owner message as mod message

### DIFF
--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -223,12 +223,14 @@
         style="display: {item.hidden ? 'none' : 'block'}"
       >
         <span>{item.text}</span>
-        <span
-          class="author"
-          class:moderator={item.types & AuthorType.moderator}
-          class:owner={item.types & AuthorType.owner}
-          >{item.author}
-          {$showTimestamp ? `(${item.timestamp})` : ''}
+        <span class="author">
+          <span
+            class:moderator={item.types & AuthorType.moderator}
+            class:owner={item.types & AuthorType.owner}
+          >
+            {item.author}
+          </span>
+          <span>{$showTimestamp ? `(${item.timestamp})` : ''}</span>
           <span class="messageActions">
             <span class="redHighlight" on:click={() => (item.hidden = true)}>
               <Icon path={mdiEyeOffOutline} size="1em" />
@@ -300,11 +302,11 @@
   }
 
   .moderator {
-    color: rgb(100, 141, 255) !important;
+    color: #5e84f1 !important;
   }
 
   .owner {
-    color: rgb(255, 217, 0) !important;
+    color: #ffd600 !important;
   }
 
   .messageActions .blueHighlight :global(.s-icon:hover) {

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -223,7 +223,7 @@
         style="display: {item.hidden ? 'none' : 'block'}"
       >
         <span>{item.text}</span>
-        <span class="author">
+        <span class="info">
           <span
             class:moderator={item.types & AuthorType.moderator}
             class:owner={item.types & AuthorType.owner}
@@ -302,11 +302,11 @@
   }
 
   .moderator {
-    color: #5e84f1 !important;
+    color: #A0BDFC !important;
   }
 
   .owner {
-    color: #ffd600 !important;
+    color: #FFD600 !important;
   }
 
   .messageActions .blueHighlight :global(.s-icon:hover) {
@@ -320,7 +320,7 @@
     display: inline-block !important;
     cursor: pointer;
   }
-  .author {
+  .info {
     font-size: 0.75em;
     color: lightgray;
   }

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -25,7 +25,7 @@ const isWhitelisted = msg => textWhitelisted(msg.text) || authorWhitelisted(msg.
 const isBlacklisted = msg => textBlacklisted(msg.text) || userBlacklisted(msg.id) || authorBlacklisted(msg.author);
 
 /** @type {(msg: Message) => Boolean} */
-const isMod = msg => msg.types & AuthorType.moderator;
+const isMod = msg => (msg.types & AuthorType.moderator) || (msg.types & AuthorType.owner);
 
 /** @type {(msg: Message) => Boolean} */
 const showIfMod = msg => isMod(msg) && showModMessage.get();


### PR DESCRIPTION
Similar to #70 before it got lost during the rewrite.

Also separated author name from timestamp and changed colors to be consistent with YTC/HyperChat.
Before:
![image](https://user-images.githubusercontent.com/20059164/116646686-478f2f80-a9ab-11eb-835d-618a9e6887b1.png)
After:
![image](https://user-images.githubusercontent.com/20059164/116646785-82916300-a9ab-11eb-9ce1-b3c31260691e.png)
