### PR TITLE
Fix/Add smooth scrolling

### DIFF
--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -1,5 +1,10 @@
 <script>
-  import { beforeUpdate, afterUpdate, onMount, onDestroy } from 'svelte';
+  import {
+    afterUpdate,
+    onMount,
+    onDestroy,
+    createEventDispatcher
+  } from 'svelte';
   import { sources, combineStores } from '../js/sources.js';
   import '../css/splash.css';
   import { Icon } from 'svelte-materialify/src';
@@ -17,27 +22,12 @@
   } from '../js/constants.js';
   $: document.body.style.fontSize = Math.round($livetlFontSize) + 'px';
   export let direction;
-  export let settingsOpen = false;
   /** @type {{ text: String, author: String, timestamp: String }[]}*/
   export let items = [];
   export let updatePopupActive = false;
 
   let bottomMsg = null;
-  let messageDisplay = null;
   let unsubscribe = null;
-  const shouldScroll = () => {
-    try {
-      const parentElem =
-        messageDisplay.parentElement.parentElement.parentElement;
-      return (
-        bottomMsg &&
-        Math.ceil(parentElem.clientHeight + parentElem.scrollTop) >=
-          parentElem.scrollHeight
-      );
-    } catch (e) {
-      return false;
-    }
-  };
   onMount(() => {
     const { cleanUp, store: source } = combineStores(
       sources.translations,
@@ -54,37 +44,22 @@
   });
   onDestroy(() => unsubscribe());
 
-  export function scrollToRecent() {
+  export function scrollToRecent(behavior='smooth') {
     bottomMsg.scrollIntoView({
-      behaviour: 'smooth',
+      behavior: behavior,
       block: 'nearest',
       inline: 'nearest'
     });
   }
 
-  let scrollOnTick = false;
-  let settingsWasOpen = false;
-  $: settingsWasOpen = !settingsOpen;
-  beforeUpdate(() => {
-    if (
-      (shouldScroll() || settingsWasOpen) &&
-      direction == TextDirection.BOTTOM
-    ) {
-      scrollOnTick = true;
-      settingsWasOpen = false;
-    }
-  });
-  afterUpdate(() => {
-    if (scrollOnTick)
-      scrollToRecent();
-    scrollOnTick = false;
-  });
+  const dispatch = createEventDispatcher();
+  afterUpdate(() => dispatch('afterUpdate'));
+  
   const version = window.chrome.runtime.getManifest().version;
 </script>
 
 <div class="messageDisplayWrapper">
   <div
-    bind:this={messageDisplay}
     class="messageDisplay"
     style="align-self: flex-{direction === TextDirection.BOTTOM
       ? 'end'

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -18,14 +18,38 @@
   let wrapper;
   let messageDisplay;
   let isAtRecent = true;
+  let checkTimer = null;
 
   function checkAtRecent() {
+    if (!wrapper) return;
     isAtRecent =
       ($textDirection === TextDirection.BOTTOM && wrapper.isAtBottom()) ||
       ($textDirection === TextDirection.TOP && wrapper.isAtTop());
   }
 
-  afterUpdate(() => checkAtRecent());
+  function checkRecentWithScroll() {
+    if (checkTimer !== null) {
+      clearTimeout(checkTimer);
+    }
+    checkTimer = setTimeout(() => checkAtRecent(), 50);
+  }
+
+  function onMessageDisplayUpdate() {
+    if (isAtRecent){
+      messageDisplay.scrollToRecent();
+    }
+  }
+
+  let settingsWasOpen = false;
+  $: settingsWasOpen = !settingsOpen;
+  afterUpdate(() => {
+    // Prevent smooth scrolling when exiting settings
+    if (settingsWasOpen) {
+      messageDisplay.scrollToRecent('auto');
+      settingsWasOpen = false;
+    }
+    checkAtRecent();
+  });
 </script>
 
 <svelte:window on:resize={checkAtRecent} />
@@ -41,16 +65,16 @@
       <Icon path={settingsOpen ? mdiClose : mdiCogOutline} />
     </Button>
   </div>
-  <Wrapper {isResizing} on:scroll={checkAtRecent} bind:this={wrapper}>
+  <Wrapper {isResizing} on:scroll={checkRecentWithScroll} bind:this={wrapper}>
     {#if settingsOpen}
       <Options {isStandalone} {isResizing} />
     {/if}
     <div style="display: {settingsOpen ? 'none' : 'block'};">
       <MessageDisplay
         direction={$textDirection}
-        {settingsOpen}
         bind:updatePopupActive
         bind:this={messageDisplay}
+        on:afterUpdate={onMessageDisplayUpdate}
       />
     </div>
   </Wrapper>
@@ -66,7 +90,7 @@
         <Button
           fab
           size="small"
-          on:click={messageDisplay.scrollToRecent}
+          on:click={() => messageDisplay.scrollToRecent()}
           class="elevation-3"
           style="background-color: #0287C3; border-color: #0287C3;"
         >


### PR DESCRIPTION
Also took the liberty of refactoring scrolling logic out of MessageDisplay. Goodbye `messageDisplay.parentElement.parentElement.parentElement`.

Side effect of smooth scrolling is now the "scroll to recent" button only appears/disappears when scrolling ends, not immediately while scrolling. 