### PR TITLE
Keep scrolling till recent

### DIFF
--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -26,7 +26,6 @@
   export let items = [];
   export let updatePopupActive = false;
 
-  let bottomMsg = null;
   let unsubscribe = null;
   onMount(() => {
     const { cleanUp, store: source } = combineStores(
@@ -44,14 +43,6 @@
   });
   onDestroy(() => unsubscribe());
 
-  export function scrollToRecent(behavior='smooth') {
-    bottomMsg.scrollIntoView({
-      behavior: behavior,
-      block: 'nearest',
-      inline: 'nearest'
-    });
-  }
-
   const dispatch = createEventDispatcher();
   afterUpdate(() => dispatch('afterUpdate'));
   
@@ -66,7 +57,8 @@
       : 'start'};
       flex-direction: column{direction === TextDirection.TOP
       ? '-reverse'
-      : ''};"
+      : ''};
+      {direction === TextDirection.TOP ? 'padding-top: 1px;' : ''}"
   >
     <div class="message">
       <div class="heading">
@@ -231,7 +223,6 @@
         </span>
       </div>
     {/each}
-    <div class="bottom 🥺" bind:this={bottomMsg} />
   </div>
 </div>
 

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -1,5 +1,10 @@
 <script>
-  import { beforeUpdate, afterUpdate, onMount, onDestroy } from 'svelte';
+  import {
+    afterUpdate,
+    onMount,
+    onDestroy,
+    createEventDispatcher
+  } from 'svelte';
   import { sources, combineStores } from '../js/sources.js';
   import '../css/splash.css';
   import { Icon } from 'svelte-materialify/src';
@@ -17,27 +22,12 @@
   } from '../js/constants.js';
   $: document.body.style.fontSize = Math.round($livetlFontSize) + 'px';
   export let direction;
-  export let settingsOpen = false;
   /** @type {{ text: String, author: String, timestamp: String }[]}*/
   export let items = [];
   export let updatePopupActive = false;
 
   let bottomMsg = null;
-  let messageDisplay = null;
   let unsubscribe = null;
-  const shouldScroll = () => {
-    try {
-      const parentElem =
-        messageDisplay.parentElement.parentElement.parentElement;
-      return (
-        bottomMsg &&
-        Math.ceil(parentElem.clientHeight + parentElem.scrollTop) >=
-          parentElem.scrollHeight
-      );
-    } catch (e) {
-      return false;
-    }
-  };
   onMount(() => {
     const { cleanUp, store: source } = combineStores(
       sources.translations,
@@ -54,37 +44,22 @@
   });
   onDestroy(() => unsubscribe());
 
-  export function scrollToRecent() {
+  export function scrollToRecent(behavior='smooth') {
     bottomMsg.scrollIntoView({
-      behaviour: 'smooth',
+      behavior: behavior,
       block: 'nearest',
       inline: 'nearest'
     });
   }
 
-  let scrollOnTick = false;
-  let settingsWasOpen = false;
-  $: settingsWasOpen = !settingsOpen;
-  beforeUpdate(() => {
-    if (
-      (shouldScroll() || settingsWasOpen) &&
-      direction == TextDirection.BOTTOM
-    ) {
-      scrollOnTick = true;
-      settingsWasOpen = false;
-    }
-  });
-  afterUpdate(() => {
-    if (scrollOnTick)
-      scrollToRecent();
-    scrollOnTick = false;
-  });
+  const dispatch = createEventDispatcher();
+  afterUpdate(() => dispatch('afterUpdate'));
+  
   const version = window.chrome.runtime.getManifest().version;
 </script>
 
 <div class="messageDisplayWrapper">
   <div
-    bind:this={messageDisplay}
     class="messageDisplay"
     style="align-self: flex-{direction === TextDirection.BOTTOM
       ? 'end'

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -25,6 +25,12 @@
   /** @type {{ text: String, author: String, timestamp: String }[]}*/
   export let items = [];
   export let updatePopupActive = false;
+  export let margin;
+  let messageDisplay;
+
+  export function getClientHeight() {
+    return messageDisplay.clientHeight;
+  }
 
   let unsubscribe = null;
   onMount(() => {
@@ -52,13 +58,17 @@
 <div class="messageDisplayWrapper">
   <div
     class="messageDisplay"
-    style="align-self: flex-{direction === TextDirection.BOTTOM
-      ? 'end'
-      : 'start'};
+    style="
+      align-self: flex-{direction === TextDirection.BOTTOM
+        ? 'end'
+        : 'start'};
       flex-direction: column{direction === TextDirection.TOP
-      ? '-reverse'
-      : ''};
-      {direction === TextDirection.TOP ? 'padding-top: 1px;' : ''}"
+        ? '-reverse'
+        : ''};
+      {direction === TextDirection.TOP
+        ? 'padding-top: 1px; margin-bottom: '.concat(margin, 'px;')
+        : 'margin-top: '.concat(margin, 'px;')}"
+    bind:this={messageDisplay}
   >
     <div class="message">
       <div class="heading">

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -20,6 +20,7 @@
   let isAtRecent = true;
   let checkTimer = null;
   let keepScrolling = false;
+  let interruptScroll = false;
 
   function checkAtRecent() {
     if (!wrapper) return false;
@@ -32,18 +33,19 @@
     messageDisplay.scrollToRecent();
   }
 
-  function checkRecentWithScroll() {
-    if (checkTimer !== null) {
+  function delayedCheckAtRecent() {
+    if (checkTimer !== null && !interruptScroll) {
       clearTimeout(checkTimer);
     }
     checkTimer = setTimeout(() => {
       const atRecent = checkAtRecent();
 
-      if (keepScrolling && !atRecent) {
+      if (keepScrolling && !atRecent && !interruptScroll) {
         messageDisplay.scrollToRecent();
       }
       else {
         keepScrolling = false;
+        interruptScroll = false;
         isAtRecent = atRecent;
       }
     }, 50);
@@ -63,7 +65,7 @@
       messageDisplay.scrollToRecent('auto');
       settingsWasOpen = false;
     }
-    isAtRecent = checkAtRecent();
+    delayedCheckAtRecent();
   });
 </script>
 
@@ -80,7 +82,12 @@
       <Icon path={settingsOpen ? mdiClose : mdiCogOutline} />
     </Button>
   </div>
-  <Wrapper {isResizing} on:scroll={checkRecentWithScroll} bind:this={wrapper}>
+  <Wrapper
+    {isResizing}
+    on:scroll={delayedCheckAtRecent}
+    on:wheel={() => (interruptScroll = true)}
+    bind:this={wrapper}
+  >
     {#if settingsOpen}
       <Options {isStandalone} {isResizing} />
     {/if}

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -51,6 +51,21 @@
     }, 50);
   }
 
+  function onWrapperKeyDown(e) {
+    const keys = ['PageUp', 'PageDown', 'Home', 'End', 'ArrowDown', 'ArrowUp'];
+    if (
+      !checkAtRecent() && (
+        (e.key === 'Home' && $textDirection === TextDirection.TOP) || 
+        (e.key === 'End' && $textDirection === TextDirection.BOTTOM)
+      )
+    ) {
+      keepScrollingToRecent();
+    }
+    else if (keys.includes(e.key)) {
+      interruptScroll = true;
+    }
+  }
+
   function onMessageDisplayUpdate() {
     if (isAtRecent && !settingsOpen) {
       keepScrollingToRecent();
@@ -86,6 +101,7 @@
     {isResizing}
     on:scroll={delayedCheckAtRecent}
     on:wheel={() => (interruptScroll = true)}
+    on:keydown={onWrapperKeyDown}
     bind:this={wrapper}
   >
     {#if settingsOpen}

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -18,14 +18,38 @@
   let wrapper;
   let messageDisplay;
   let isAtRecent = true;
+  let checkTimer = null;
 
   function checkAtRecent() {
+    if (!wrapper) return;
     isAtRecent =
       ($textDirection === TextDirection.BOTTOM && wrapper.isAtBottom()) ||
       ($textDirection === TextDirection.TOP && wrapper.isAtTop());
   }
 
-  afterUpdate(() => checkAtRecent());
+  function checkRecentWithScroll() {
+    if (checkTimer !== null) {
+      clearTimeout(checkTimer);
+    }
+    checkTimer = setTimeout(() => checkAtRecent(), 50);
+  }
+
+  function onMessageDisplayUpdate() {
+    if (isAtRecent){
+      messageDisplay.scrollToRecent();
+    }
+  }
+
+  let settingsWasOpen = false;
+  $: settingsWasOpen = !settingsOpen;
+  afterUpdate(() => {
+    // Prevent smooth scrolling when exiting settings
+    if (settingsWasOpen) {
+      messageDisplay.scrollToRecent('auto');
+      settingsWasOpen = false;
+    }
+    checkAtRecent();
+  });
 </script>
 
 <svelte:window on:resize={checkAtRecent} />
@@ -41,16 +65,16 @@
       <Icon path={settingsOpen ? mdiClose : mdiCogOutline} />
     </Button>
   </div>
-  <Wrapper {isResizing} on:scroll={checkAtRecent} bind:this={wrapper}>
+  <Wrapper {isResizing} on:scroll={checkRecentWithScroll} bind:this={wrapper}>
     {#if settingsOpen}
       <Options {isStandalone} {isResizing} />
     {/if}
     <div style="display: {settingsOpen ? 'none' : 'block'};">
       <MessageDisplay
         direction={$textDirection}
-        {settingsOpen}
         bind:updatePopupActive
         bind:this={messageDisplay}
+        on:afterUpdate={onMessageDisplayUpdate}
       />
     </div>
   </Wrapper>
@@ -66,7 +90,7 @@
         <Button
           fab
           size="small"
-          on:click={messageDisplay.scrollToRecent}
+          on:click={() => messageDisplay.scrollToRecent()}
           class="elevation-3"
           style="background-color: #0287C3; border-color: #0287C3;"
         >

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { beforeUpdate } from 'svelte';
+  import { beforeUpdate, afterUpdate } from 'svelte';
   import { fade } from 'svelte/transition';
   import { Button, Icon, MaterialApp } from 'svelte-materialify/src';
   import { mdiClose, mdiCogOutline, mdiArrowDown, mdiArrowUp } from '@mdi/js';
@@ -114,12 +114,20 @@
   }
 
   let settingsWasOpen = false;
+  let wasResizing = false;
   $: settingsWasOpen = !settingsOpen;
+  $: wasResizing = !isResizing;
   beforeUpdate(() => {
     // Prevent smooth scrolling when exiting settings
     if (settingsWasOpen) {
       smoothScroll = false;
       settingsWasOpen = false;
+    }
+  });
+  afterUpdate(() => {
+    if (wasResizing && document.readyState === 'complete') {
+      updateMargin();
+      wasResizing = false;
     }
   });
 </script>

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -22,6 +22,7 @@
   let keepScrolling = false;
   let interruptScroll = false;
   let smoothScroll = true;
+  let messageDisplayMargin = 0;
   const topScrollOffset = 1;
 
   function checkAtRecent() {
@@ -46,6 +47,21 @@
     scrollToRecent();
   }
 
+  function updateMargin() {
+    if (isResizing || settingsOpen) return;
+
+    const wrapperHeight = wrapper.getClientHeight();
+    const messageDisplayHeight = messageDisplay.getClientHeight();
+    const offset = ($textDirection === TextDirection.BOTTOM ? 1 : 2);
+
+    if (messageDisplayHeight > wrapperHeight) {
+      messageDisplayMargin = 0;
+    }
+    else {
+      messageDisplayMargin = wrapperHeight - messageDisplayHeight + offset;
+    }
+  }
+
   function onWrapperScroll() {
     if ($textDirection === TextDirection.TOP && checkAtRecent()) {
       wrapper.scrollToTop(topScrollOffset);
@@ -55,6 +71,7 @@
       clearTimeout(checkTimer);
     }
     checkTimer = setTimeout(() => {
+      updateMargin();
       const atRecent = checkAtRecent();
 
       if (keepScrolling && !atRecent && !interruptScroll) {
@@ -107,7 +124,16 @@
   });
 </script>
 
-<svelte:window on:resize={() => (isAtRecent = checkAtRecent())} />
+<svelte:window 
+  on:resize={() => {
+    updateMargin();
+    isAtRecent = checkAtRecent();
+  }}
+  on:load={() => {
+    updateMargin();
+    scrollToRecent();
+  }}
+/>
 
 <MaterialApp theme="dark">
   <div
@@ -135,6 +161,7 @@
     <div style="display: {settingsOpen ? 'none' : 'block'};">
       <MessageDisplay
         direction={$textDirection}
+        margin={messageDisplayMargin}
         bind:updatePopupActive
         bind:this={messageDisplay}
         on:afterUpdate={onMessageDisplayAfterUpdate}

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -19,24 +19,39 @@
   let messageDisplay;
   let isAtRecent = true;
   let checkTimer = null;
+  let keepScrolling = false;
 
   function checkAtRecent() {
-    if (!wrapper) return;
-    isAtRecent =
-      ($textDirection === TextDirection.BOTTOM && wrapper.isAtBottom()) ||
+    if (!wrapper) return false;
+    return ($textDirection === TextDirection.BOTTOM && wrapper.isAtBottom()) ||
       ($textDirection === TextDirection.TOP && wrapper.isAtTop());
+  }
+
+  function keepScrollingToRecent() {
+    keepScrolling = true;
+    messageDisplay.scrollToRecent();
   }
 
   function checkRecentWithScroll() {
     if (checkTimer !== null) {
       clearTimeout(checkTimer);
     }
-    checkTimer = setTimeout(() => checkAtRecent(), 50);
+    checkTimer = setTimeout(() => {
+      const atRecent = checkAtRecent();
+
+      if (keepScrolling && !atRecent) {
+        messageDisplay.scrollToRecent();
+      }
+      else {
+        keepScrolling = false;
+        isAtRecent = atRecent;
+      }
+    }, 50);
   }
 
   function onMessageDisplayUpdate() {
-    if (isAtRecent){
-      messageDisplay.scrollToRecent();
+    if (isAtRecent && !settingsOpen) {
+      keepScrollingToRecent();
     }
   }
 
@@ -48,11 +63,11 @@
       messageDisplay.scrollToRecent('auto');
       settingsWasOpen = false;
     }
-    checkAtRecent();
+    isAtRecent = checkAtRecent();
   });
 </script>
 
-<svelte:window on:resize={checkAtRecent} />
+<svelte:window on:resize={() => (isAtRecent = checkAtRecent())} />
 
 <MaterialApp theme="dark">
   <div
@@ -90,7 +105,7 @@
         <Button
           fab
           size="small"
-          on:click={() => messageDisplay.scrollToRecent()}
+          on:click={keepScrollingToRecent}
           class="elevation-3"
           style="background-color: #0287C3; border-color: #0287C3;"
         >

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -19,9 +19,7 @@
 
 <div
   style="
-    display: {isResizing
-    ? 'none'
-    : 'grid'};
+    display: {isResizing ? 'none' : 'grid'};
     width: {inverse}%;
     height: {inverse}%;
     transform-origin: 0px 0px;

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -23,6 +23,9 @@
   export function scrollToTop(offset=0) {
     div.scrollTop = 0 + offset;
   }
+  export function getClientHeight() {
+    return div.clientHeight;
+  }
 
   const dispatch = createEventDispatcher();
   afterUpdate(() => dispatch('afterUpdate'));

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -1,8 +1,10 @@
 <script>
+  import { afterUpdate, createEventDispatcher } from 'svelte';
   export let isResizing;
   export let zoom = NaN;
   export let verticalCenter = false;
   export let style = '';
+  export let smoothScroll = false;
   let factor;
   $: factor = zoom || 1;
   let inverse;
@@ -12,9 +14,18 @@
   export function isAtBottom() {
     return Math.ceil(div.clientHeight + div.scrollTop) >= div.scrollHeight;
   }
-  export function isAtTop() {
-    return div.scrollTop === 0;
+  export function isAtTop(offset=0) {
+    return div.scrollTop <= (0 + offset);
   }
+  export function scrollToBottom() {
+    div.scrollTop = div.scrollHeight - div.clientHeight;
+  }
+  export function scrollToTop(offset=0) {
+    div.scrollTop = 0 + offset;
+  }
+
+  const dispatch = createEventDispatcher();
+  afterUpdate(() => dispatch('afterUpdate'));
 </script>
 
 <div
@@ -26,6 +37,8 @@
     transform: scale({factor});
     overflow: auto;
     position: absolute;
+    scroll-behavior: {smoothScroll ? 'smooth' : 'auto'};
+    scrollbar-width: thin;
     {style}
     "
   bind:this={div}

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -30,6 +30,7 @@
     "
   bind:this={div}
   on:scroll
+  on:wheel
 >
   <slot />
 </div>

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -31,6 +31,8 @@
   bind:this={div}
   on:scroll
   on:wheel
+  on:keydown
+  tabindex="0"
 >
   <slot />
 </div>

--- a/src/components/settings/UISettings.svelte
+++ b/src/components/settings/UISettings.svelte
@@ -10,7 +10,8 @@
     showTimestamp,
     speechVolume,
     textDirection,
-    enableCaptionTimeout
+    enableCaptionTimeout,
+    smoothAutoScroll
   } from '../../js/store.js';
   import { TextDirection, VideoSide } from '../../js/constants.js';
   import CheckOption from '../options/Toggle.svelte';
@@ -39,6 +40,7 @@
   />
   <!-- {/if} -->
 </div>
+<CheckOption name="Smooth auto-scroll" store={smoothAutoScroll} />
 <CheckOption name="Show timestamps" store={showTimestamp} />
 <!-- {#if !isStandalone} -->
 <CheckOption name="Show captions" store={showCaption} />

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -57,4 +57,5 @@ export const
   regexAuthorBlacklist = SS('regexAuthorBlacklist', [''].slice(1)),
   customFilters = SS('customFilters', [sampleFilter].slice(1)),
   enableCaptionTimeout = SS('enableCaptionTimeout', false),
-  lastVersion = SS('lastVersion', '0.0.0');
+  lastVersion = SS('lastVersion', '0.0.0'),
+  smoothAutoScroll = SS('smoothAutoScroll', true);


### PR DESCRIPTION
Update of #209, previously if a new TL/message is added while auto scrolling, scrolling stops before said new message. 

This fix changes auto scroll to keep scrolling until the most recent message is reached for both message updates and when clicking the "scroll to recent" button.

A known issue with this change is that the user can't interrupt the auto scroll until it stops, and neither `on:wheel` nor `on:mousewheel` wanted to play nice when I tried to use them for user interrupt. Personally I think this is pretty minor, and is only a significant problem if you're trying to scroll while TL messages are updating with speeds akin to having `.*` regex filter on (which no one realistically does).