### PR TITLE
Refactor MessageDisplay scrolling

### DIFF
--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -1,5 +1,10 @@
 <script>
-  import { beforeUpdate, afterUpdate, onMount, onDestroy } from 'svelte';
+  import {
+    afterUpdate,
+    onMount,
+    onDestroy,
+    createEventDispatcher
+  } from 'svelte';
   import { sources, combineStores } from '../js/sources.js';
   import '../css/splash.css';
   import { Icon } from 'svelte-materialify/src';
@@ -17,27 +22,12 @@
   } from '../js/constants.js';
   $: document.body.style.fontSize = Math.round($livetlFontSize) + 'px';
   export let direction;
-  export let settingsOpen = false;
   /** @type {{ text: String, author: String, timestamp: String }[]}*/
   export let items = [];
   export let updatePopupActive = false;
 
   let bottomMsg = null;
-  let messageDisplay = null;
   let unsubscribe = null;
-  const shouldScroll = () => {
-    try {
-      const parentElem =
-        messageDisplay.parentElement.parentElement.parentElement;
-      return (
-        bottomMsg &&
-        Math.ceil(parentElem.clientHeight + parentElem.scrollTop) >=
-          parentElem.scrollHeight
-      );
-    } catch (e) {
-      return false;
-    }
-  };
   onMount(() => {
     const { cleanUp, store: source } = combineStores(
       sources.translations,
@@ -56,35 +46,20 @@
 
   export function scrollToRecent() {
     bottomMsg.scrollIntoView({
-      behaviour: 'smooth',
+      behavior: 'auto',
       block: 'nearest',
       inline: 'nearest'
     });
   }
 
-  let scrollOnTick = false;
-  let settingsWasOpen = false;
-  $: settingsWasOpen = !settingsOpen;
-  beforeUpdate(() => {
-    if (
-      (shouldScroll() || settingsWasOpen) &&
-      direction == TextDirection.BOTTOM
-    ) {
-      scrollOnTick = true;
-      settingsWasOpen = false;
-    }
-  });
-  afterUpdate(() => {
-    if (scrollOnTick)
-      scrollToRecent();
-    scrollOnTick = false;
-  });
+  const dispatch = createEventDispatcher();
+  afterUpdate(() => dispatch('afterUpdate'));
+  
   const version = window.chrome.runtime.getManifest().version;
 </script>
 
 <div class="messageDisplayWrapper">
   <div
-    bind:this={messageDisplay}
     class="messageDisplay"
     style="align-self: flex-{direction === TextDirection.BOTTOM
       ? 'end'

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -26,7 +26,21 @@
       ($textDirection === TextDirection.TOP && wrapper.isAtTop());
   }
 
-  afterUpdate(() => checkAtRecent());
+  function onMessageDisplayAfterUpdate() {
+    if (isAtRecent && !settingsOpen){
+      messageDisplay.scrollToRecent();
+    }
+  }
+
+  let settingsWasOpen = false;
+  $: settingsWasOpen = !settingsOpen;
+  afterUpdate(() => {
+    if (settingsWasOpen) {
+      messageDisplay.scrollToRecent();
+      settingsWasOpen = false;
+    }
+    checkAtRecent();
+  });
 </script>
 
 <svelte:window on:resize={checkAtRecent} />
@@ -50,9 +64,9 @@
     <div style="display: {settingsOpen ? 'none' : 'block'};">
       <MessageDisplay
         direction={$textDirection}
-        {settingsOpen}
         bind:updatePopupActive
         bind:this={messageDisplay}
+        on:afterUpdate={onMessageDisplayAfterUpdate}
       />
     </div>
   </Wrapper>

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -28,6 +28,7 @@
     transform: scale({factor});
     overflow: auto;
     position: absolute;
+    scrollbar-width: thin;
     {style}
     "
   bind:this={div}


### PR DESCRIPTION
Here's the scrolling refactors from a50dbef. This is functionally the same with current, just slightly nicer looking code (no `messageDisplay.parentElement.parentElement.parentElement`).

I've also added `scrollbar-width: thin;` so LiveTL scrollbar looks consistent with HyperChat scrollbar on Firefox.