### PR TITLE
Add a dismiss button to Welcome message

### DIFF
--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -5,15 +5,17 @@
     onDestroy,
     createEventDispatcher
   } from 'svelte';
-  import { Checkbox, Button } from 'svelte-materialify/src';
+  import { Checkbox, Icon } from 'svelte-materialify/src';
   import { sources, combineStores } from '../js/sources.js';
+  import Minimizer from "./Minimizer.svelte";
   import '../css/splash.css';
-  import { Icon } from 'svelte-materialify/src';
-  import { mdiEyeOffOutline, mdiAccountRemove, mdiClose } from '@mdi/js';
+  import { mdiEyeOffOutline, mdiAccountRemove, mdiChevronDown, mdiChevronUp } from '@mdi/js';
   import {
     channelFilters,
     livetlFontSize,
-    showTimestamp
+    showTimestamp,
+    welcomeDismissed,
+    textDirection
   } from '../js/store.js';
   import {
     BROWSER,
@@ -64,7 +66,6 @@
 
   export let screenshotting = false;
   export let selectedItems = [];
-  let showWelcomeMessage = true;
 
   $: if (!screenshotting) selectedItems = [];
 </script>
@@ -79,25 +80,23 @@
       ? '-reverse'
       : ''};"
   >
-    {#if showWelcomeMessage}
-      <div class="message">
+    <div class="message transition">
+      {#if $textDirection == TextDirection.BOTTOM}
+        <Minimizer />
+      {/if}
+      {#if !$welcomeDismissed}
         <div class="heading">
           <h2>Welcome to LiveTL!</h2>
-          <Button
-            fab
-            size="small"
-            on:click={() => (showWelcomeMessage = false)}
-          >
-            <Icon path={mdiClose} />
-          </Button>
         </div>
-        <div class="subheading">
-          Translations picked up from the chat will appear here.
+      {/if}
+      <div class="subheading">
+        Translations picked up from the chat will appear here.
+        {#if !$welcomeDismissed}
           <p style="font-size: 0.8em;">
             <a
               href="https://livetl.app/"
               target="about:blank"
-              on:click={(e) => {
+              on:click={e => {
                 e.preventDefault();
                 // eslint-disable-next-line no-unused-vars
                 updatePopupActive = true;
@@ -106,53 +105,55 @@
               See what's new in v{version}
             </a>
           </p>
-        </div>
+        {/if}
+      </div>
+      {#if !$welcomeDismissed}
         <div class="subscripts">
           <div class="badges">
             <!--
-          <a
-            href="https://livetl.app/"
-            target="about:blank"
-            on:click={e => {
-              e.preventDefault();
-              // eslint-disable-next-line no-unused-vars
-              updatePopupActive = true;
-            }}
-          >
-            <img
-              alt="Version"
-              src="https://img.shields.io/badge/See what's new in-v{version}-blue?style=flat&color=ff69b4"
-            />
-          </a>
-          <a
-            href="https://chrome.google.com/webstore/detail/livetl-translation-filter/moicohcfhhbmmngneghfjfjpdobmmnlg"
-            target="about:blank"
-          >
-            <img
-              alt="Chrome Web Store"
-              src="https://img.shields.io/chrome-web-store/users/moicohcfhhbmmngneghfjfjpdobmmnlg?color=blue&label=Chrome%20users&logo=google&logoColor=white&style=flat"
-            />
-          </a>
-          <a
-            href="https://addons.mozilla.org/en-US/firefox/addon/livetl/"
-            target="about:blank"
-          >
-            <img
-              alt="Mozilla Addons"
-              src="https://img.shields.io/amo/users/livetl?color=blue&label=Firefox%20users&logo=mozilla&logoColor=white&style=flat"
-            />
-          </a>
-          <a href="https://livetl.app/" target="about:blank">
-            <img
-              alt="Other platforms"
-              src="https://img.shields.io/badge/Other%20platforms-Android%2C%20iOS-blue?style=flat"
-            />
-          </a>
-          -->
+        <a
+          href="https://livetl.app/"
+          target="about:blank"
+          on:click={e => {
+            e.preventDefault();
+            // eslint-disable-next-line no-unused-vars
+            updatePopupActive = true;
+          }}
+        >
+          <img
+            alt="Version"
+            src="https://img.shields.io/badge/See what's new in-v{version}-blue?style=flat&color=ff69b4"
+          />
+        </a>
+        <a
+          href="https://chrome.google.com/webstore/detail/livetl-translation-filter/moicohcfhhbmmngneghfjfjpdobmmnlg"
+          target="about:blank"
+        >
+          <img
+            alt="Chrome Web Store"
+            src="https://img.shields.io/chrome-web-store/users/moicohcfhhbmmngneghfjfjpdobmmnlg?color=blue&label=Chrome%20users&logo=google&logoColor=white&style=flat"
+          />
+        </a>
+        <a
+          href="https://addons.mozilla.org/en-US/firefox/addon/livetl/"
+          target="about:blank"
+        >
+          <img
+            alt="Mozilla Addons"
+            src="https://img.shields.io/amo/users/livetl?color=blue&label=Firefox%20users&logo=mozilla&logoColor=white&style=flat"
+          />
+        </a>
+        <a href="https://livetl.app/" target="about:blank">
+          <img
+            alt="Other platforms"
+            src="https://img.shields.io/badge/Other%20platforms-Android%2C%20iOS-blue?style=flat"
+          />
+        </a>
+        -->
             <a
               href="/"
               target="about:blank"
-              on:click={(e) => {
+              on:click={e => {
                 e.preventDefault();
                 if (BROWSER === Browser.CHROME) {
                   window.open(
@@ -181,13 +182,13 @@
               />
             </a>
             <!--
-          <a href="https://livetl.app/" target="about:blank">
-            <img
-              alt="Website"
-              src="https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=blue&up_message=livetl.app&url=http%3A%2F%2Flivetl.app%2F&style=flat"
-            />
-          </a>
-          -->
+        <a href="https://livetl.app/" target="about:blank">
+          <img
+            alt="Website"
+            src="https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=blue&up_message=livetl.app&url=http%3A%2F%2Flivetl.app%2F&style=flat"
+          />
+        </a>
+        -->
             <a href="https://opencollective.com/livetl" target="about:blank">
               <img
                 alt="Donators and supporters"
@@ -195,16 +196,16 @@
               />
             </a>
             <!--
-          <a
-            href="https://hosted.weblate.org/engage/livetl/"
-            target="about:blank"
-          >
-            <img
-              alt="Localization"
-              src="https://img.shields.io/badge/Localization-Weblate-blue"
-            />
-          </a>
-          -->
+        <a
+          href="https://hosted.weblate.org/engage/livetl/"
+          target="about:blank"
+        >
+          <img
+            alt="Localization"
+            src="https://img.shields.io/badge/Localization-Weblate-blue"
+          />
+        </a>
+        -->
             <a href="https://discord.gg/uJrV3tmthg" target="about:blank">
               <img
                 alt="Discord"
@@ -213,12 +214,11 @@
             </a>
           </div>
         </div>
-      </div>
-    {:else if !items.length}
-      <div class="message">
-        <span> Translations picked up from the chat will appear here. </span>
-      </div>
-    {/if}
+      {/if}
+      {#if $textDirection == TextDirection.TOP}
+        <Minimizer />
+      {/if}
+    </div>
     {#each items as item}
       <div
         class="message"
@@ -247,9 +247,9 @@
                 channelFilters.set(item.id, {
                   ...channelFilters.get(item.id),
                   name: item.author,
-                  blacklist: true,
+                  blacklist: true
                 });
-                items = items.filter((i) => i.id != item.id);
+                items = items.filter(i => i.id != item.id);
               }}
             >
               <Icon path={mdiAccountRemove} size="1em" />

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -265,6 +265,7 @@
 <style>
   h2 {
     font-size: 1.5em;
+    line-height: 1.5em;
   }
   .badges {
     margin-top: 10px;

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -5,11 +5,11 @@
     onDestroy,
     createEventDispatcher
   } from 'svelte';
-  import { Checkbox } from 'svelte-materialify/src';
+  import { Checkbox, Button } from 'svelte-materialify/src';
   import { sources, combineStores } from '../js/sources.js';
   import '../css/splash.css';
   import { Icon } from 'svelte-materialify/src';
-  import { mdiEyeOffOutline, mdiAccountRemove } from '@mdi/js';
+  import { mdiEyeOffOutline, mdiAccountRemove, mdiClose } from '@mdi/js';
   import {
     channelFilters,
     livetlFontSize,
@@ -21,6 +21,7 @@
     AuthorType,
     TextDirection
   } from '../js/constants.js';
+
   $: document.body.style.fontSize = Math.round($livetlFontSize) + 'px';
   export let direction;
   /** @type {{ text: String, author: String, timestamp: String }[]}*/
@@ -63,6 +64,7 @@
 
   export let screenshotting = false;
   export let selectedItems = [];
+  let showWelcomeMessage = true;
 
   $: if (!screenshotting) selectedItems = [];
 </script>
@@ -77,29 +79,37 @@
       ? '-reverse'
       : ''};"
   >
-    <div class="message">
-      <div class="heading">
-        <strong> Welcome to LiveTL! </strong>
-      </div>
-      <div class="subheading">
-        Translations picked up from the chat will appear here.
-        <p style="font-size: 0.8em;">
-          <a
-            href="https://livetl.app/"
-            target="about:blank"
-            on:click={e => {
-              e.preventDefault();
-              // eslint-disable-next-line no-unused-vars
-              updatePopupActive = true;
-            }}
+    {#if showWelcomeMessage}
+      <div class="message">
+        <div class="heading">
+          <h2>Welcome to LiveTL!</h2>
+          <Button
+            fab
+            size="small"
+            on:click={() => (showWelcomeMessage = false)}
           >
-            See what's new in v{version}
-          </a>
-        </p>
-      </div>
-      <div class="subscripts">
-        <div class="badges">
-          <!--
+            <Icon path={mdiClose} />
+          </Button>
+        </div>
+        <div class="subheading">
+          Translations picked up from the chat will appear here.
+          <p style="font-size: 0.8em;">
+            <a
+              href="https://livetl.app/"
+              target="about:blank"
+              on:click={(e) => {
+                e.preventDefault();
+                // eslint-disable-next-line no-unused-vars
+                updatePopupActive = true;
+              }}
+            >
+              See what's new in v{version}
+            </a>
+          </p>
+        </div>
+        <div class="subscripts">
+          <div class="badges">
+            <!--
           <a
             href="https://livetl.app/"
             target="about:blank"
@@ -139,38 +149,38 @@
             />
           </a>
           -->
-          <a
-            href="/"
-            target="about:blank"
-            on:click={e => {
-              e.preventDefault();
-              if (BROWSER === Browser.CHROME) {
-                window.open(
-                  'https://chrome.google.com/webstore/detail/livetl-live-translations/moicohcfhhbmmngneghfjfjpdobmmnlg/reviews'
-                );
-              } else if (BROWSER === Browser.FIREFOX) {
-                window.open(
-                  'https://addons.mozilla.org/en-US/firefox/addon/livetl'
-                );
-              } else {
-                window.open(
-                  'https://chrome.google.com/webstore/detail/livetl-live-translations/moicohcfhhbmmngneghfjfjpdobmmnlg/reviews'
-                );
-              }
-            }}
-          >
-            <img
-              alt="Reviews"
-              src="https://img.shields.io/badge/Leave a review-5%20stars-blue?style=flat"
-            />
-          </a>
-          <a href="https://github.com/LiveTL/LiveTL/" target="about:blank">
-            <img
-              alt="GitHub Repo"
-              src="https://img.shields.io/github/stars/LiveTL/LiveTL?style=flat&logo=github&label=Star on GitHub"
-            />
-          </a>
-          <!--
+            <a
+              href="/"
+              target="about:blank"
+              on:click={(e) => {
+                e.preventDefault();
+                if (BROWSER === Browser.CHROME) {
+                  window.open(
+                    'https://chrome.google.com/webstore/detail/livetl-live-translations/moicohcfhhbmmngneghfjfjpdobmmnlg/reviews'
+                  );
+                } else if (BROWSER === Browser.FIREFOX) {
+                  window.open(
+                    'https://addons.mozilla.org/en-US/firefox/addon/livetl'
+                  );
+                } else {
+                  window.open(
+                    'https://chrome.google.com/webstore/detail/livetl-live-translations/moicohcfhhbmmngneghfjfjpdobmmnlg/reviews'
+                  );
+                }
+              }}
+            >
+              <img
+                alt="Reviews"
+                src="https://img.shields.io/badge/Leave a review-5%20stars-blue?style=flat"
+              />
+            </a>
+            <a href="https://github.com/LiveTL/LiveTL/" target="about:blank">
+              <img
+                alt="GitHub Repo"
+                src="https://img.shields.io/github/stars/LiveTL/LiveTL?style=flat&logo=github&label=Star on GitHub"
+              />
+            </a>
+            <!--
           <a href="https://livetl.app/" target="about:blank">
             <img
               alt="Website"
@@ -178,13 +188,13 @@
             />
           </a>
           -->
-          <a href="https://opencollective.com/livetl" target="about:blank">
-            <img
-              alt="Donators and supporters"
-              src="https://img.shields.io/opencollective/all/livetl?color=blue&label=Donators%20and%20supporters&logo=dollar&style=flat"
-            />
-          </a>
-          <!--
+            <a href="https://opencollective.com/livetl" target="about:blank">
+              <img
+                alt="Donators and supporters"
+                src="https://img.shields.io/opencollective/all/livetl?color=blue&label=Donators%20and%20supporters&logo=dollar&style=flat"
+              />
+            </a>
+            <!--
           <a
             href="https://hosted.weblate.org/engage/livetl/"
             target="about:blank"
@@ -195,15 +205,20 @@
             />
           </a>
           -->
-          <a href="https://discord.gg/uJrV3tmthg" target="about:blank">
-            <img
-              alt="Discord"
-              src="https://img.shields.io/discord/780938154437640232.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2&style=flat"
-            />
-          </a>
+            <a href="https://discord.gg/uJrV3tmthg" target="about:blank">
+              <img
+                alt="Discord"
+                src="https://img.shields.io/discord/780938154437640232.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2&style=flat"
+              />
+            </a>
+          </div>
         </div>
       </div>
-    </div>
+    {:else if !items.length}
+      <div class="message">
+        <span> Translations picked up from the chat will appear here. </span>
+      </div>
+    {/if}
     {#each items as item}
       <div
         class="message"
@@ -232,9 +247,9 @@
                 channelFilters.set(item.id, {
                   ...channelFilters.get(item.id),
                   name: item.author,
-                  blacklist: true
+                  blacklist: true,
                 });
-                items = items.filter(i => i.id != item.id);
+                items = items.filter((i) => i.id != item.id);
               }}
             >
               <Icon path={mdiAccountRemove} size="1em" />
@@ -248,6 +263,9 @@
 </div>
 
 <style>
+  h2 {
+    font-size: 1.5em;
+  }
   .badges {
     margin-top: 10px;
   }
@@ -255,7 +273,9 @@
     height: 1.5em;
   }
   .heading {
-    font-size: 1.5em;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
   .subheading {
     font-size: 1em;

--- a/src/components/Minimizer.svelte
+++ b/src/components/Minimizer.svelte
@@ -46,6 +46,7 @@
     overflow: hidden !important;
     background-color: transparent !important;
     border-radius: 10px !important;
+    box-shadow: none !important;
   }
 
   .minimizeContainer {

--- a/src/components/Minimizer.svelte
+++ b/src/components/Minimizer.svelte
@@ -1,0 +1,64 @@
+<script>
+  import {
+    welcomeDismissed,
+    textDirection
+  } from '../js/store.js';
+  import { Button, Icon } from 'svelte-materialify/src';
+  import { mdiChevronDown, mdiChevronUp } from '@mdi/js';
+  import {
+    TextDirection
+  } from '../js/constants.js';
+</script>
+
+<div
+  class="minimizeContainer"
+  style="transform: translateX(calc(0px - var(--margin))) {$textDirection ==
+  TextDirection.BOTTOM
+    ? 'translateY(-5px)'
+    : ''} !important;"
+>
+  <Button
+    fab
+    class="minimizeBar"
+    on:click={() => ($welcomeDismissed = !$welcomeDismissed)}
+  >
+    <Icon
+      path={[mdiChevronDown, mdiChevronUp][
+        $welcomeDismissed
+          ? $textDirection == TextDirection.BOTTOM
+            ? 1
+            : 0
+          : $textDirection == TextDirection.TOP
+          ? 1
+          : 0
+      ]}
+    />
+  </Button>
+</div>
+
+<style>
+  :global(.minimizeBar) {
+    margin-left: 0px !important;
+    height: 10px !important;
+    width: 100% !important;
+    display: flex;
+    justify-content: center;
+    overflow: hidden !important;
+    background-color: transparent !important;
+    border-radius: 10px !important;
+  }
+
+  .minimizeContainer {
+    height: 5px !important;
+    display: flex !important;
+    flex-direction: column !important;
+    width: calc(100% + 2 * var(--margin)) !important;
+    align-items: center !important;
+  }
+
+  .minimizeContainer :global(.s-btn__content) {
+    /* background-color: rgba(255, 255, 255, 0.1) !important; */
+    box-shadow: none !important;
+  }
+
+</style>

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -59,4 +59,5 @@ export const
   enableCaptionTimeout = SS('enableCaptionTimeout', false),
   chatSplit = SS('chatSplit', ChatSplit.HORIZONTAL),
   lastVersion = SS('lastVersion', '0.0.0'),
-  screenshotRenderWidth = SS('screenshotRenderWidth', 500);
+  screenshotRenderWidth = SS('screenshotRenderWidth', 500),
+  welcomeDismissed = SS('welcomeDismissed', false);


### PR DESCRIPTION
**Why**
The welcome message is a bit of an eye-soar and takes up a lot of space. Furthermore it never goes away even as translations come in (which makes it harder to notice translation messages coming in), so I thought it would be nice to give the user the option to dismiss it, without otherwise affecting the experience.

**What's changed**
- Added a dismiss button to the right of the "Welcome" text
- Clicking dismiss button hides the majority of the welcome message, and replaces it with a smaller message saying that translations will show up here.
- The message 'Translations picked up from the chat' is removed once the first translated message is picked up

**What didn't change**
- The welcome message still shows up every time the extension is loaded (dismissing only lasts for the current session).

**Screenshots**
Default state:
![image](https://user-images.githubusercontent.com/12624925/119552488-83db6300-bd92-11eb-86bc-0e7d6da6ab29.png)


After clicking X:
![image](https://user-images.githubusercontent.com/12624925/119549194-e3d00a80-bd8e-11eb-808c-1644298e68e1.png)
