### PR TITLE
Options panel takes up full height of container

### DIFF
--- a/src/components/Options.svelte
+++ b/src/components/Options.svelte
@@ -27,7 +27,7 @@
   .app {
     padding: 0px !important;
     justify-content: center;
-    max-height: 100%;
+    height: 100%;
   }
   :global(body) {
     margin: 0px 0px;


### PR DESCRIPTION
**Why:**
Options page doesn't take up full height of the container, causing the tab menu to jump up and down when switching between "Interface" and "Filters"
It looks a lot nicer if the options just takes up 100% of the height

**Changed:**
change `max-height: 100%` to `height: 100%` (options component).


**Screenshots**
After changes:
![image](https://user-images.githubusercontent.com/12624925/119576026-e131dd00-bdaf-11eb-8126-c0ef2bb61a43.png)

Before changes:
![image](https://user-images.githubusercontent.com/12624925/119576034-e68f2780-bdaf-11eb-8363-e9ba6f743740.png)


note: scrolling still works