### PR TITLE
Remove margin from captions box

### DIFF
--- a/src/components/Captions.svelte
+++ b/src/components/Captions.svelte
@@ -82,9 +82,7 @@
   left: min(max({$captionLeft}%, calc(0% - 20px)), calc(100% - 30px));
   width: max(0%, {$captionWidth}%);
   font-size: {$captionFontSize}px;
-  display: {show
-    ? 'block'
-    : 'none'};
+  display: {show ? 'block' : 'none'};
 "
 >
   <div class="captionSegment" bind:this={elem}>
@@ -111,12 +109,10 @@
     padding: 5px 10px;
     animation-iteration-count: 1;
     animation: splash 1s normal forwards ease-in-out;
-    margin: 20px;
     backdrop-filter: blur(5px);
   }
   .captionsBox :global(.ui-resizable-handle) {
-    height: calc(100% - 40px);
-    margin-top: 20px;
+    height: 100%;
   }
   .captionsBox :global(.ui-resizable-e) {
     transform: translateX(-10px);
@@ -124,4 +120,5 @@
   .captionsBox :global(.ui-resizable-w) {
     transform: translateX(10px);
   }
+
 </style>


### PR DESCRIPTION
**Why**
The captions container has a 20px margin, which I presume was either for the purpose of positioning the captions away from the edge of the screen, or to increase the draggable area.
The margin can prevent you from being able to click elements underneath it, when it appears like you should be able to.
For example, if the captions are close to the youtube videos' bottom bar, the margin around the captions box prevents you from being able to click on the youtube bottom bar, which is frustrating.

With margin applied, you are unable to interact with the youtube videos bottom bar, even though it looks like you can
![image](https://user-images.githubusercontent.com/12624925/119576714-302c4200-bdb1-11eb-8aac-aa52ccadcd37.png)

**Changes**
Remove margin from captions box