### PR TITLE
Fix URLs in TLs

### DIFF
--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -7,9 +7,9 @@
   } from 'svelte';
   import { Checkbox, Icon } from 'svelte-materialify/src';
   import { sources, combineStores } from '../js/sources.js';
-  import Minimizer from "./Minimizer.svelte";
+  import Minimizer from './Minimizer.svelte';
   import '../css/splash.css';
-  import { mdiEyeOffOutline, mdiAccountRemove, mdiChevronDown, mdiChevronUp } from '@mdi/js';
+  import { mdiEyeOffOutline, mdiAccountRemove } from '@mdi/js';
   import {
     channelFilters,
     livetlFontSize,
@@ -228,7 +228,15 @@
         {#if screenshotting}
           <Checkbox bind:group={selectedItems} value={item} />
         {/if}
-        <span>{item.text}</span>
+        {#each item.messageArray as message}
+          {#if message.type === 'text'}
+            <span>{message.text}</span>
+          {:else if message.type === 'link'}
+            <a class="chatLink" href={message.url} target="_blank">{message.text}</a>
+          {:else if message.type === 'emote' && message.src}
+            <img class="chatEmote" src={message.src} alt="emote" />
+          {/if}
+        {/each}
         <span class="info">
           <span
             class:moderator={item.types & AuthorType.moderator}
@@ -342,8 +350,20 @@
   .message:nth-child(odd) {
     background-color: rgba(255, 255, 255, 0.075);
   }
+
   .message:nth-child(even) {
     background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .chatEmote {
+    vertical-align: sub;
+    height: 1.5em;
+    width: 1.5em;
+    margin: 0px 0.2em 0px 0.2em;
+  }
+
+  .chatLink {
+    color: var(--theme-text-primary);
   }
 
 </style>

--- a/src/js/parse-chat.js
+++ b/src/js/parse-chat.js
@@ -62,7 +62,19 @@ export const parseChatResponse = response =>{
       const runs = [];
       if (messageItem.message) {
         messageItem.message.runs.forEach((run) => {
-          if (run.text) {
+          if (run.text && run.navigationEndpoint) {
+            let url = run.navigationEndpoint.commandMetadata.webCommandMetadata.url;
+            if (url.startsWith('/')) {
+              url = 'https://www.youtube.com'.concat(url);
+            }
+            runs.push({
+              type: 'link',
+              text: decodeURIComponent(escape(unescape(encodeURIComponent(
+                run.text
+              )))),
+              url: url
+            });
+          } else if (run.text) {
             runs.push({
               type: 'text',
               text: decodeURIComponent(escape(unescape(encodeURIComponent(

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -102,11 +102,11 @@ function getYTCData(unparsed) {
 
 function ytcToMsg({ message, timestamp, author: { name: author, id, types } }) {
   const text = message
-    .filter(item => item.type === 'text')
+    .filter(item => item.type === 'text' || item.type === 'link')
     .map(item => item.text)
     .join('');
   const typeFlag = types.reduce((flag, t) => flag | AuthorType[t], 0);
-  return { text, timestamp, author, id, types: typeFlag };
+  return { text, timestamp, author, id, types: typeFlag, messageArray: message };
 }
 
 function forwardPostMessages(window) {


### PR DESCRIPTION
Similar to LiveTL/chat#10, this PR fixes URLs in the LiveTL output.

Before:
![image](https://user-images.githubusercontent.com/20059164/119992522-39115380-bffd-11eb-81af-57a556e95a31.png)

After:
![image](https://user-images.githubusercontent.com/20059164/119992548-3f9fcb00-bffd-11eb-918e-39a556b2135f.png)

My suggested fix also incidentally allows member emotes to be shown in the LiveTL output. I've included it in the commit, but I can remove it if it's not desired. Example:
![image](https://user-images.githubusercontent.com/20059164/119992984-ad4bf700-bffd-11eb-9e11-9aedf99cf6ef.png)

Messages that only contain emotes will never be shown in the LiveTL output, since they don't contain any text and will fail the trim() check.