### PR TITLE
Chat zoom - round to 2 decimal places

### DIFF
--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -1,10 +1,9 @@
 <script>
   export let isResizing;
   export let zoom = NaN;
-  export let verticalCenter = false;
   export let style = '';
   let factor;
-  $: factor = zoom || 1;
+  $: factor = parseFloat(zoom.toFixed(2)) || 1;
   let inverse;
   $: inverse = 100 / factor;
 


### PR DESCRIPTION
Previously, the default chat zoom would be 1.0025, this slight difference above 1 causes the text in pinned messages to be blurry when the chat is scaled. (This is a chrome bug that happens, probably due to the animation on the pinned messages).

While this doesn't fix the blurriness if the chat zoom is anything other than 1, it will at least ensure that the text looks clear on the default zoom setting.

- Fixes #227
