### PR TITLE
Fix translation tag not filtered out

### DIFF
--- a/src/components/About.svelte
+++ b/src/components/About.svelte
@@ -1,15 +1,11 @@
 <script>
-  import { onMount } from 'svelte';
-  import { ExpansionPanel, ExpansionPanels, Row } from 'svelte-materialify/src';
+  import { ExpansionPanel, ExpansionPanels } from 'svelte-materialify/src';
   import opencollective from '../plugins/opencollective.json';
   import gh from '../plugins/gh.json';
-
-  export let isStandalone = false;
 
   const compareAttr = attr => (a, b) => a[attr] - b[attr];
   const reverseCompare = cmp => (a, b) => -cmp(a, b);
   const compareDono = reverseCompare(compareAttr('totalAmountDonated'));
-  const toJson = r => r.json();
   const uniqueBy = attr => arr => {
     const vals = new Set();
     return arr.filter(v => {

--- a/src/components/ImportExport.svelte
+++ b/src/components/ImportExport.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Button, Icon, Textarea, Chip } from 'svelte-materialify';
+  import { Button, Icon, Textarea } from 'svelte-materialify';
   import { mdiCheck, mdiClipboardOutline, mdiClose } from '@mdi/js';
   import { importStores, exportStores } from '../js/storage.js';
   import { compose } from '../js/utils.js';
@@ -111,16 +111,6 @@
   .buttons.vertical :global(.import-button) {
     width: 100%;
     margin-bottom: 1%;
-  }
-
-  .header {
-    display: flex;
-    flex-direction: row;
-    margin-bottom: 2%;
-  }
-
-  .header > * {
-    flex-grow: 1;
   }
 
   :global(label) {

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -8,7 +8,7 @@
   import { TextDirection } from '../js/constants.js';
   import { textDirection, screenshotRenderWidth } from '../js/store.js';
   import MessageDisplay from './MessageDisplay.svelte';
-  import ScreenshotExport from "./ScreenshotExport.svelte";
+  import ScreenshotExport from './ScreenshotExport.svelte';
   import Updates from './Updates.svelte';
   let settingsOpen = false;
   export let isResizing = false;

--- a/src/components/ScreenshotExport.svelte
+++ b/src/components/ScreenshotExport.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { tick } from "svelte";
+  import { tick } from 'svelte';
   import html2canvas from 'html2canvas';
   window.html2canvas = html2canvas;
   export let renderQueue = [];
@@ -8,13 +8,13 @@
   let rendering = false;
   let image = '';
   import { ProgressLinear } from 'svelte-materialify/src';
-  import Dialog from "./Dialog.svelte";
+  import Dialog from './Dialog.svelte';
   $: if (renderQueue.length) {
     (async () => {
       rendering = true;
       await tick();
       const canvas = await html2canvas(renderElement);
-      const base64image = canvas.toDataURL("image/png");
+      const base64image = canvas.toDataURL('image/png');
       image = base64image;
       renderQueue = [];
       rendering = false;

--- a/src/components/Updates.svelte
+++ b/src/components/Updates.svelte
@@ -7,7 +7,6 @@
 
   const manifest = window.chrome.runtime.getManifest();
   const version = versionMap(manifest.version);
-  const lvLoaded = lastVersion.loaded;
 
   export let active = false;
 

--- a/src/components/Welcome.svelte
+++ b/src/components/Welcome.svelte
@@ -44,7 +44,7 @@
                they are available.`
   }, {
     prompt: 'A translator is using their own style of language tags.',
-    response: `You can manually select additional users to filter in the settings.`
+    response: 'You can manually select additional users to filter in the settings.'
   }];
 </script>
 

--- a/src/components/options/CustomFilter.svelte
+++ b/src/components/options/CustomFilter.svelte
@@ -10,7 +10,6 @@
   export let plainReg = 'plain';
   export let chatAuthor = 'chat';
   export let id = '';
-  export let isNew = false;
 
   let div;
   let maxRuleLength = 0;

--- a/src/components/settings/FilterSettings.svelte
+++ b/src/components/settings/FilterSettings.svelte
@@ -20,7 +20,6 @@
   import CustomFilter from '../options/CustomFilter.svelte';
   import SelectOption from '../options/Dropdown.svelte';
   import MultiDropdown from '../options/MultiDropdown.svelte';
-  export let isStandalone = false;
 
   function createNewFilter() {
     cleanupFilters();

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -55,6 +55,10 @@ function attachFilters(translations, mod, ytc) {
     const parsed = parseTranslation(text);
     if (!text) return;
     if (isTranslation(parsed)) {
+      if (message.messageArray[0].type === 'text') {
+        const originalText = message.messageArray[0].text;
+        message.messageArray[0].text = parseTranslation(originalText).msg;
+      }
       setTranslation(message, parsed.msg);
     }
     else if (isWhitelisted(message)) {


### PR DESCRIPTION
When a valid translation is found, the text of `messageArray[0]` will go though `parseTranslation` to remove TL tags.

I've also done some miscellaneous formatting and yarn warning resolutions.