### PR TITLE
E2e reduce concurrency

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Build extension
       run: yarn e2e:build
     - name: Run tests
-      run: DISCORD_REPORT_HOOK=${{ secrets.DISCORD_WEBHOOK }} pytest --tests-per-worker 3 e2e
+      run: DISCORD_REPORT_HOOK=${{ secrets.DISCORD_WEBHOOK }} pytest --tests-per-worker 1 e2e

--- a/e2e/test_ext.py
+++ b/e2e/test_ext.py
@@ -171,8 +171,10 @@ def test_embed_tl_scroll(web):
 
     # Scroll to the top
     switch_to_embed_frame(web)
-    web.execute_script("document.querySelector('.message-display-wrapper .message').scrollIntoView()")
-    assert retry_bool(scroll_to_bottom_buttons), "scroll to bottom button isn't displayed"
+    @retry
+    def _():
+        web.execute_script("document.querySelector('.message-display-wrapper .message').scrollIntoView()")
+        assert scroll_to_bottom_buttons(), "scroll to bottom button isn't displayed"
     scroll_to_bottom_buttons()[0].click()
     time.sleep(1) # button doesn't immediately go away
     assert retry_bool(lambda: not scroll_to_bottom_buttons()), "scroll to bottom button is still displayed"


### PR DESCRIPTION
Reducing concurrency seems to make the tests execute faster and not error as much.