### PR TITLE
Remove mod deleted messages from filtered output 

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jquery-ui-bundle": "^1.12.1-migrate",
     "reconnecting-eventsource": "^1.1.0",
     "ssri": "^8.0.1",
-    "svelte-materialify": "^0.3.11",
+    "svelte-materialify": "0.3.6",
     "vue": "^2.6.12",
     "vuetify": "^2.4.9",
     "youtube-iframe": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jquery-ui-bundle": "^1.12.1-migrate",
     "reconnecting-eventsource": "^1.1.0",
     "ssri": "^8.0.1",
-    "svelte-materialify": "^0.3.6",
+    "svelte-materialify": "^0.3.11",
     "vue": "^2.6.12",
     "vuetify": "^2.4.9",
     "youtube-iframe": "^1.0.3"

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -15,6 +15,8 @@
   export let showTimestamp = false;
   export let thin = false;
   export let inanimate = true;
+  export let deleted = false;
+  export let messageArray = [];
 
   const dispatch = createEventDispatcher();
 
@@ -27,12 +29,13 @@
   class="message"
   class:inanimate
   class:thin
+  class:deleted
   style="display: {hidden ? 'none' : 'block'}"
 >
   <!-- For screenshot checkmark -->
   <slot />
 
-  {#each message.messageArray as msg}
+  {#each messageArray as msg}
     {#if msg.type === 'text'}
       <span>{msg.text}</span>
     {:else if msg.type === 'link'}
@@ -108,6 +111,7 @@
   .info {
     font-size: 0.75em;
     color: lightgray;
+    font-style: normal;
   }
 
   .chat-link {
@@ -125,5 +129,10 @@
     background-color: rgba(255, 255, 255, 0.25);
     padding: 2px;
     border-radius: 5px;
+  }
+
+  .deleted {
+    font-style: italic;
+    color: #898888;
   }
 </style>

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -16,9 +16,13 @@
   export let thin = false;
   export let inanimate = true;
   export let deleted = false;
-  export let messageArray = [];
+  export let messageArray = null;
 
   const dispatch = createEventDispatcher();
+
+  if (!messageArray && message) {
+    messageArray = message.messageArray;
+  }
 
   $: moderator = message.types & AuthorType.moderator;
   $: owner = message.types & AuthorType.owner;

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -26,7 +26,7 @@
 
   $: document.body.style.fontSize = Math.round($livetlFontSize) + 'px';
   export let direction;
-  /** @type {{ text: String, author: String, timestamp: String, authorId: string, messageId: string, hidden: boolean, messageArray: any[] }[]}*/
+  /** @type {{ text: String, author: String, timestamp: String, authorId: string, messageId: string, hidden: boolean, messageArray: any[], deleted: boolean }[]}*/
   export let items = [];
 
   let bottomMsg = null;
@@ -47,7 +47,8 @@
       if ($ytcDeleteBehaviour === YtcDeleteBehaviour.HIDE) {
         items[i].hidden = true;
       } else if ($ytcDeleteBehaviour === YtcDeleteBehaviour.PLACEHOLDER) {
-        items[i].messageArray = bonkOrDeletion.replacedMessage; //FIXME: The object gets replaced but UI doesn't update
+        items[i].messageArray = bonkOrDeletion.replacedMessage;
+        items[i].deleted = true;
       }
     };
     const bonkUnsub = sources.ytcBonks.subscribe(bonks => {
@@ -122,6 +123,8 @@
         message={item}
         hidden={item.hidden}
         showTimestamp={$showTimestamp}
+        deleted={item.deleted}
+        messageArray={item.messageArray}
         on:hide={() => (item.hidden = true)}
         on:ban={banMessage(item)}
       >

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -21,12 +21,13 @@
     TextDirection,
     YtcDeleteBehaviour
   } from '../js/constants.js';
-
   import IntroMessage from './IntroMessage.svelte';
+  // eslint-disable-next-line no-unused-vars
+  import { MessageItem } from '../js/types.js';
 
   $: document.body.style.fontSize = Math.round($livetlFontSize) + 'px';
   export let direction;
-  /** @type {{ text: String, author: String, timestamp: String, authorId: string, messageId: string, hidden: boolean, messageArray: any[], deleted: boolean }[]}*/
+  /** @type {{ text: String, author: String, timestamp: String, authorId: string, messageId: string, hidden: boolean, messageArray: MessageItem[], deleted: boolean }[]}*/
   export let items = [];
 
   let bottomMsg = null;

--- a/src/components/settings/FilterSettings.svelte
+++ b/src/components/settings/FilterSettings.svelte
@@ -6,7 +6,8 @@
     customFilters,
     channelFilters,
     enableMchadTLs,
-    enableAPITLs
+    enableAPITLs,
+    ytcDeleteBehaviour
   } from '../../js/store.js';
   import {
     Row,
@@ -17,7 +18,7 @@
   } from 'svelte-materialify/src';
   import { mdiPlus } from '@mdi/js';
   import { addFilter, cleanupFilters } from '../../js/filter.js';
-  import { languageNameValues } from '../../js/constants.js';
+  import { languageNameValues, ytcDeleteValues } from '../../js/constants.js';
   import CheckOption from '../options/Toggle.svelte';
   import CustomFilter from '../options/CustomFilter.svelte';
   import SelectOption from '../options/Dropdown.svelte';
@@ -36,6 +37,11 @@
   name="Language filter"
   store={language}
   items={languageNameValues}
+/>
+<SelectOption
+  name="When messages are deleted by moderators:"
+  store={ytcDeleteBehaviour}
+  items={ytcDeleteValues}
 />
 <CheckOption name="Show moderator messages" store={showModMessage} />
 <MultiDropdown

--- a/src/components/settings/FilterSettings.svelte
+++ b/src/components/settings/FilterSettings.svelte
@@ -23,6 +23,7 @@
   import CustomFilter from '../options/CustomFilter.svelte';
   import SelectOption from '../options/Dropdown.svelte';
   import MultiDropdown from '../options/MultiDropdown.svelte';
+  import { Radio } from 'svelte-materialify/src';
 
   function createNewFilter() {
     cleanupFilters();
@@ -31,17 +32,14 @@
 
   onMount(cleanupFilters);
 
+  $: deleteBehaviourGroup = $ytcDeleteBehaviour;
+  $: ytcDeleteBehaviour.set(deleteBehaviourGroup);
 </script>
 
 <SelectOption
   name="Language filter"
   store={language}
   items={languageNameValues}
-/>
-<SelectOption
-  name="When messages are deleted by moderators:"
-  store={ytcDeleteBehaviour}
-  items={ytcDeleteValues}
 />
 <CheckOption name="Show moderator messages" store={showModMessage} />
 <MultiDropdown
@@ -52,6 +50,12 @@
   setBool={(n, v) =>
     channelFilters.set(n, { ...channelFilters.get(n), blacklist: v })}
 />
+<Subheader>When messages are deleted by moderators:</Subheader>
+{#each [...ytcDeleteValues.keys()] as key}
+  <Radio bind:group={deleteBehaviourGroup} value={key} style='padding-bottom: 5px;' color='blue'>
+    {ytcDeleteValues.get(key)}
+  </Radio>
+{/each}
 <Row>
   <Col>
     <Subheader>External translation sources</Subheader>

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -97,7 +97,7 @@ export const YtcDeleteBehaviour = {
 };
 
 export const ytcDeleteValues = [
-  {name: 'Hide TL', value: YtcDeleteBehaviour.HIDE},
+  {name: 'Hide message', value: YtcDeleteBehaviour.HIDE},
   {name: 'Show placeholder', value: YtcDeleteBehaviour.PLACEHOLDER},
   {name: 'Do nothing', value: YtcDeleteBehaviour.NOTHING}
 ];

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -89,3 +89,15 @@ export const paramsEmbedded = params.get('embedded');
 export const paramsContinuation = params.get('continuation');
 export const paramsIsVOD = params.get('isReplay');
 export const paramsEmbedDomain = params.get('embed_domain');
+
+export const YtcDeleteBehaviour = {
+  HIDE: 'HIDE',
+  PLACEHOLDER: 'PLACEHOLDER',
+  NOTHING: 'NOTHING'
+};
+
+export const ytcDeleteValues = [
+  {name: 'Hide TL', value: YtcDeleteBehaviour.HIDE},
+  {name: 'Show placeholder', value: YtcDeleteBehaviour.PLACEHOLDER},
+  {name: 'Do nothing', value: YtcDeleteBehaviour.NOTHING}
+];

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -90,14 +90,15 @@ export const paramsContinuation = params.get('continuation');
 export const paramsIsVOD = params.get('isReplay');
 export const paramsEmbedDomain = params.get('embed_domain');
 
+/** @enum {String} */
 export const YtcDeleteBehaviour = {
   HIDE: 'HIDE',
   PLACEHOLDER: 'PLACEHOLDER',
   NOTHING: 'NOTHING'
 };
 
-export const ytcDeleteValues = [
-  {name: 'Hide message', value: YtcDeleteBehaviour.HIDE},
-  {name: 'Show placeholder', value: YtcDeleteBehaviour.PLACEHOLDER},
-  {name: 'Do nothing', value: YtcDeleteBehaviour.NOTHING}
-];
+export const ytcDeleteValues = new Map([
+  [YtcDeleteBehaviour.HIDE, 'Hide message'],
+  [YtcDeleteBehaviour.PLACEHOLDER, 'Show placeholder'],
+  [YtcDeleteBehaviour.NOTHING, 'Do nothing']
+]);

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -13,7 +13,7 @@ import * as MCHAD from './mchad.js';
 import * as API from './api.js';
 
 
-/** @type {{ ytcTranslations: Writable<Message>, mod: Writable<Message>, ytc: Writable<Message>, mchad: Readable<Message>, api: Readable<Message>, ytcBonks: Writable<any[]>, ytcDeletions:Writable<any[]> }} */
+/** @type {{ ytcTranslations: Writable<Message>, mod: Writable<Message>, ytc: Writable<Message>, translations: Writable<Message>, mchad: Readable<Message>, api: Readable<Message>, ytcBonks: Writable<any[]>, ytcDeletions:Writable<any[]> }} */
 export const sources = {
   ytcTranslations: writable(null),
   mod: writable(null),

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -13,13 +13,15 @@ import * as MCHAD from './mchad.js';
 import * as API from './api.js';
 
 
-/** @type {{ translations: Writable<Message>, mod: Writable<Message>, ytc: Writable<Message>, mchad: Readable<Message>, api: Readable<Message>}} */
+/** @type {{ ytcTranslations: Writable<Message>, mod: Writable<Message>, ytc: Writable<Message>, mchad: Readable<Message>, api: Readable<Message>, ytcBonks: Writable<any[]>, ytcDeletions:Writable<any[]> }} */
 export const sources = {
   ytcTranslations: writable(null),
   mod: writable(null),
   ytc: ytcSource(window).ytc,
   mchad: combineStores(MCHAD.getArchive(paramsVideoId), MCHAD.getLiveTranslations(paramsVideoId)).store,
   api: combineStores(API.getArchive(paramsVideoId), API.getLiveTranslations(paramsVideoId)).store,
+  ytcBonks: writable(null),
+  ytcDeletions: writable(null),
 };
 
 /** @type {(id: String) => Boolean} */
@@ -29,7 +31,7 @@ const userBlacklisted = id => channelFilters.get(id).blacklist;
 const isWhitelisted = msg => textWhitelisted(msg.text) || authorWhitelisted(msg.author);
 
 /** @type {(msg: Message) => Boolean} */
-const isBlacklisted = msg => textBlacklisted(msg.text) || userBlacklisted(msg.id) || authorBlacklisted(msg.author);
+const isBlacklisted = msg => textBlacklisted(msg.text) || userBlacklisted(msg.authorId) || authorBlacklisted(msg.author);
 
 /** @type {(msg: Message) => Boolean} */
 const isMod = msg => (msg.types & AuthorType.moderator) || (msg.types & AuthorType.owner);
@@ -37,7 +39,7 @@ const isMod = msg => (msg.types & AuthorType.moderator) || (msg.types & AuthorTy
 /** @type {(msg: Message) => Boolean} */
 const showIfMod = msg => isMod(msg) && showModMessage.get();
 
-/** @type {(store: Writable<Message>) => (msg: Message, text: String | undefined) => void} */
+/** @type {(store: Writable<Message>) => (msg: Message, text?: String) => void} */
 const setStoreMessage =
   store => (msg, text) => store.set({ ...msg, text: text ?? msg.text });
 
@@ -108,15 +110,28 @@ export function combineStores(...stores) {
   };
 }
 
-function ytcToMsg({ message, timestamp, author: { name: author, id, types } }) {
-  const text = message
+/**
+ * @returns {Message}
+ */
+function ytcToMsg(ytcMessage) {
+  const text = ytcMessage.message
     .filter(item => item.type === 'text' || item.type === 'link')
     .map(item => item.text)
     .join('');
-  const typeFlag = types.reduce((flag, t) => flag | AuthorType[t], 0);
-  return { text, timestamp, author, id, types: typeFlag, messageArray: message };
+  const author = ytcMessage.author;
+  const typeFlag = author.types.reduce((flag, t) => flag | AuthorType[t], 0);
+  return {
+    text,
+    timestamp: ytcMessage.timestamp,
+    author: author.name,
+    authorId: author.id,
+    types: typeFlag,
+    messageArray: ytcMessage.message,
+    messageId: ytcMessage.messageId
+  };
 }
 
+/**@param {Window} window */
 export function ytcSource(window) {
   /** @type {Writable<Message>} */
   const ytc = writable(null);
@@ -205,10 +220,20 @@ export function ytcSource(window) {
     }
   });
 
+  const filterDeleted = (message, bonks, deletions) => {
+    return !(bonks.some((b) => b.authorId === message.author.id) ||
+      deletions.some((d) => d.messageId === message.messageId));
+  };
+
   port.onMessage.addListener((payload) => {
     if (payload.type === 'actionChunk') {
       firstChunkReceived = true;
-      pushMessagesToQueue(payload.messages);
+      const messages = payload.messages.filter(
+        (m) => filterDeleted(m, payload.bonks, payload.deletions)
+      );
+      sources.ytcBonks.set(payload.bonks);
+      sources.ytcDeletions.set(payload.deletions);
+      pushMessagesToQueue(messages);
       if (!isPollingProgress() && !payload.isReplay) {
         startVideoProgressUpdatePolling();
       }

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,4 +1,4 @@
-import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit } from './constants.js';
+import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour } from './constants.js';
 import { LookupStore, SyncStore } from './storage.js';
 import { writable } from 'svelte/store';
 
@@ -68,7 +68,8 @@ export const
   enableMchadTLs = SS('enableMchadTLs', true),
   enableAPITLs = SS('enableAPITLs', true),
   enableExportButtons = SS('enableExportButtons', true),
-  enableFullscreenButton = SS('enableFullscreenButton', true);
+  enableFullscreenButton = SS('enableFullscreenButton', true),
+  ytcDeleteBehaviour = SS('ytcDeleteBehaviour', YtcDeleteBehaviour.HIDE);
 
 // Non-persistant stores
 export const updatePopupActive = writable(false);

--- a/src/js/types.js
+++ b/src/js/types.js
@@ -2,7 +2,7 @@
 /** @typedef {{type: 'link', url: String, text: String}} LinkMessage */
 /** @typedef {{type: 'emote', src: String}} EmoteMessage */
 /** @typedef {TextMessage | LinkMessage | EmoteMessage} MessageItem */
-/** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, id: String, types: Number}} Message */
+/** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, types: Number, authorId: string, messageId: string}} Message */
 
 /** @typedef {Number} Seconds */
 /** @typedef {Number} UnixTimestamp */

--- a/yarn.lock
+++ b/yarn.lock
@@ -7113,10 +7113,10 @@ svelte-loader@^3.1.2:
     svelte-dev-helper "^1.1.9"
     svelte-hmr "^0.14.2"
 
-svelte-materialify@^0.3.11:
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/svelte-materialify/-/svelte-materialify-0.3.11.tgz#bdd0a73961e9b408bb584bf2d85b2bb39e5424e9"
-  integrity sha512-MLtZtdSOHditOdJOYqlB8s7NxIFRbYKXJzij5s9gz5WVbJFVEqdX2TqOleg4wYeMOujtOCm+/x3RP5YGyzRxIQ==
+svelte-materialify@0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/svelte-materialify/-/svelte-materialify-0.3.6.tgz#a2d4c42ddfcca4bd36625b0481c8daa62dae3b4d"
+  integrity sha512-tiENt0PkgIGa2alIAu3pAVUakQwNpWpxiudUDNyVo0igDuvPzXy/39R+wvPdM4HabjYUdsfoghiOsUcpHCLxIg==
 
 svelte-preprocess@^4.6.9:
   version "4.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7113,10 +7113,10 @@ svelte-loader@^3.1.2:
     svelte-dev-helper "^1.1.9"
     svelte-hmr "^0.14.2"
 
-svelte-materialify@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/svelte-materialify/-/svelte-materialify-0.3.6.tgz#a2d4c42ddfcca4bd36625b0481c8daa62dae3b4d"
-  integrity sha512-tiENt0PkgIGa2alIAu3pAVUakQwNpWpxiudUDNyVo0igDuvPzXy/39R+wvPdM4HabjYUdsfoghiOsUcpHCLxIg==
+svelte-materialify@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/svelte-materialify/-/svelte-materialify-0.3.11.tgz#bdd0a73961e9b408bb584bf2d85b2bb39e5424e9"
+  integrity sha512-MLtZtdSOHditOdJOYqlB8s7NxIFRbYKXJzij5s9gz5WVbJFVEqdX2TqOleg4wYeMOujtOCm+/x3RP5YGyzRxIQ==
 
 svelte-preprocess@^4.6.9:
   version "4.6.9"


### PR DESCRIPTION
Adds support to handle YTC moderator message deletion/author ban actions. 

By default it will hide the deleted/banned messages, but there is an option under filter settings to show the placeholder text from YTC instead, or to ignore these actions entirely.

I've also updated svelte-materialify to the current latest (0.3.11) to support dropdowns that show its the selected object's name property instead of its value property:

Old (0.3.6)|New (0.3.11)
---|---
![image](https://user-images.githubusercontent.com/20059164/127639035-908b948e-7fac-4b40-876b-20ce58d4a082.png)|![image](https://user-images.githubusercontent.com/20059164/127639142-4c87ab2c-0cc5-4712-bb30-48b4d134ae76.png)

Closes #269.