### PR TITLE
Add viewport meta tags to pages

### DIFF
--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -101,7 +101,7 @@
     screenshotRenderWidth.set(renderWidthInt);
   }
 
-  
+
   function toggleFullScreen() {
     if (
       (document.fullScreenElement && document.fullScreenElement !== null) ||

--- a/src/empty.html
+++ b/src/empty.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title></title>
   <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">


### PR DESCRIPTION
This fixes scaling issues in the Android app.

Somebody should probably test this in the browsers too, since I'm not entirely familiar with the process.