### PR TITLE
Display mode refactor

### DIFF
--- a/src/components/BrowserAction.svelte
+++ b/src/components/BrowserAction.svelte
@@ -6,7 +6,7 @@
 
 <MaterialApp theme="dark">
   <Wrapper>
-    <Options isStandalone />
+    <Options />
   </Wrapper>
 </MaterialApp>
 

--- a/src/components/Options.svelte
+++ b/src/components/Options.svelte
@@ -1,7 +1,6 @@
 <script>
   import { MaterialApp } from 'svelte-materialify/src';
   import Settings from './Settings.svelte';
-  export let isResizing = false;
   export let active = false;
 
   // Hot reload window.mchad
@@ -17,7 +16,7 @@
 <MaterialApp theme="dark">
   <div class="wrapper">
     <div class="app">
-      <Settings {isResizing} bind:active />
+      <Settings bind:active />
     </div>
     <slot />
   </div>
@@ -43,5 +42,4 @@
     height: 100%;
     position: absolute;
   }
-
 </style>

--- a/src/components/Options.svelte
+++ b/src/components/Options.svelte
@@ -1,7 +1,6 @@
 <script>
   import { MaterialApp } from 'svelte-materialify/src';
   import Settings from './Settings.svelte';
-  export let isStandalone = false;
   export let isResizing = false;
   export let active = false;
 
@@ -18,7 +17,7 @@
 <MaterialApp theme="dark">
   <div class="wrapper">
     <div class="app">
-      <Settings {isStandalone} {isResizing} bind:active />
+      <Settings {isResizing} bind:active />
     </div>
     <slot />
   </div>

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -6,7 +6,7 @@
   import { mdiAccountVoiceOff } from '../js/svg.js';
   import Options from './Options.svelte';
   import Wrapper from './Wrapper.svelte';
-  import { TextDirection, paramsVideoTitle, paramsEmbedded, isAndroid } from '../js/constants.js';
+  import { TextDirection, paramsVideoTitle, isAndroid } from '../js/constants.js';
   import { faviconURL, textDirection, screenshotRenderWidth, videoTitle, enableExportButtons, updatePopupActive, enableFullscreenButton, spotlightedTranslator, isResizing } from '../js/store.js';
   import MessageDisplay from './MessageDisplay.svelte';
   import ScreenshotExport from './ScreenshotExport.svelte';

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -7,12 +7,11 @@
   import Options from './Options.svelte';
   import Wrapper from './Wrapper.svelte';
   import { TextDirection, paramsVideoTitle, paramsEmbedded, isAndroid } from '../js/constants.js';
-  import { faviconURL, textDirection, screenshotRenderWidth, videoTitle, enableExportButtons, updatePopupActive, enableFullscreenButton, spotlightedTranslator } from '../js/store.js';
+  import { faviconURL, textDirection, screenshotRenderWidth, videoTitle, enableExportButtons, updatePopupActive, enableFullscreenButton, spotlightedTranslator, isResizing } from '../js/store.js';
   import MessageDisplay from './MessageDisplay.svelte';
   import ScreenshotExport from './ScreenshotExport.svelte';
   import Updates from './Updates.svelte';
   import { saveAs } from 'file-saver';
-  import { isResizing } from '../js/store.js';
   let settingsOpen = false;
   $videoTitle = paramsVideoTitle || $videoTitle;
   $: document.title = $videoTitle || 'LiveTL Popout';

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -12,8 +12,8 @@
   import ScreenshotExport from './ScreenshotExport.svelte';
   import Updates from './Updates.svelte';
   import { saveAs } from 'file-saver';
+  import { isResizing } from '../js/store.js';
   let settingsOpen = false;
-  export let isResizing = false;
   $videoTitle = paramsVideoTitle || $videoTitle;
   $: document.title = $videoTitle || 'LiveTL Popout';
 
@@ -153,7 +153,7 @@
   <div
     class="settings-button d-flex"
     class:bottom-float={$textDirection === TextDirection.TOP}
-    class:d-none={isResizing}
+    class:d-none={$isResizing}
   >
     {#if isSelecting}
       <h6 class="floating-text">
@@ -267,9 +267,9 @@
       {/if}
     </div>
   </div>
-  <Wrapper {isResizing} on:scroll={updateWrapper} bind:this={wrapper}>
+  <Wrapper on:scroll={updateWrapper} bind:this={wrapper}>
     <div class:d-none={!settingsOpen}>
-      <Options {isResizing} bind:active={settingsOpen} />
+      <Options bind:active={settingsOpen} />
     </div>
     <div class:d-none={settingsOpen}>
       <MessageDisplay
@@ -282,7 +282,7 @@
       />
     </div>
   </Wrapper>
-  {#if !(isResizing || settingsOpen)}
+  {#if !($isResizing || settingsOpen)}
     {#if !isAtRecent}
       <div
         class="recent-button"

--- a/src/components/Popout.svelte
+++ b/src/components/Popout.svelte
@@ -16,7 +16,6 @@
   export let isResizing = false;
   $videoTitle = paramsVideoTitle || $videoTitle;
   $: document.title = $videoTitle || 'LiveTL Popout';
-  export let isStandalone = paramsEmbedded ? true : false;
 
   let wrapper;
   let messageDisplay;
@@ -270,7 +269,7 @@
   </div>
   <Wrapper {isResizing} on:scroll={updateWrapper} bind:this={wrapper}>
     <div class:d-none={!settingsOpen}>
-      <Options {isStandalone} {isResizing} bind:active={settingsOpen} />
+      <Options {isResizing} bind:active={settingsOpen} />
     </div>
     <div class:d-none={settingsOpen}>
       <MessageDisplay

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -7,7 +7,6 @@
   import TranslatorMode from './settings/TranslatorMode.svelte';
   import About from './About.svelte';
 
-  export let isStandalone = false;
   export let isResizing = false;
 
   const settings = [
@@ -93,7 +92,7 @@
               <div
                 style="font-size: 16px !important; margin: 15px 0px 15px 0px;"
               >
-                <svelte:component this={component} {isStandalone} />
+                <svelte:component this={component} />
               </div>
             </TabContent>
           {/each}

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -6,8 +6,7 @@
   import FilterSettings from './settings/FilterSettings.svelte';
   import TranslatorMode from './settings/TranslatorMode.svelte';
   import About from './About.svelte';
-
-  export let isResizing = false;
+  import { isResizing } from '../js/store.js';
 
   const settings = [
     { name: 'Interface', component: UISettings, icon: mdiBrush },
@@ -37,7 +36,7 @@
 
   let callRedrawSlider = false;
   let wasResizing = false;
-  $: wasResizing = !isResizing;
+  $: wasResizing = !$isResizing;
   beforeUpdate(() => {
     if (wasResizing) {
       callRedrawSlider = true;

--- a/src/components/Watch.svelte
+++ b/src/components/Watch.svelte
@@ -94,34 +94,33 @@
   $: isLeftSide = $videoSide == VideoSide.LEFT;
   $: isFullPage = $displayMode === DisplayMode.FULLPAGE;
   $: isChatVertical = $chatSplit == ChatSplit.VERTICAL;
+
+  $: chatElemStyle = (
+    isChatVertical ? `width: ${$chatSize}%; min-width: `: `height: ${chatSize}%; min-height: `
+  ) + '10px;';
+  $: videoContainerStyle = (
+    (isTopSide ? 'height' : `width`) + `: ${$videoPanelSize}%; ` + 
+    (isLeftSide ? 'min-width: 10px;' : (isTopSide ? 'min-height: 10px;': ''))
+  );
+  $: chatElemParentStyle = isRightSide ? 'width: calc(100% - 10px);' : '';
 </script>
 
-<div
-  style="
-  margin: 20px 0px 0px 20px;
-  position: relative;
-  width: 100vw;
-  height: calc(100% - 40px);"
->
+<div class="watch-wrapper">
   <MaterialApp theme="dark">
     {#if isFullPage && $showCaption}
       <Captions />
     {/if}
     <div
       id="mainUI"
-      class="flex 
-        {isTopSide ? 'horizontal' : 'vertical'} 
-        {isRightSide ? 'reversed' : ''}"
+      class="flex"
+      class:horizontal={isTopSide}
+      class:vertical={!isTopSide}
+      class:reversed={isRightSide}
     >
       {#if isFullPage}
         <div
           class="tile resizable"
-          style="{(isTopSide ? 'height' : `width`) + `: ${$videoPanelSize}%;`}
-            {isLeftSide
-            ? 'min-width: 10px;'
-            : isTopSide
-            ? 'min-height: 10px'
-            : ''}"
+          style={videoContainerStyle}
           bind:this={vidElem}
         >
           <Wrapper>
@@ -135,28 +134,17 @@
         style={isTopSide ? 'min-width: 100% !important;' : ''}
       >
         <div
-          class="flex {isChatVertical
-            ? 'vertical'
-            : 'horizontal'}"
-          style="
-            {isRightSide ? 'width: calc(100% - 10px);' : ''}"
+          class="flex {isChatVertical ? 'vertical' : 'horizontal'}"
+          style={chatElemParentStyle}
         >
           <div
             class="tile resizable"
-            style="{isChatVertical
-              ? 'width'
-              : 'height'}: {$chatSize}%;
-                min-{isChatVertical
-              ? 'width'
-              : 'height'}: 10px;
-            "
+            style={chatElemStyle}
             bind:this={chatElem}
           >
             <Wrapper
               zoom={$chatZoom}
-              style={isChatVertical
-                ? 'padding-right: 10px;'
-                : 'padding-bottom: 10px;'}
+              style={`padding-${isChatVertical ? 'right' : 'left'}: 10px;`}
             >
               <ChatEmbed
                 videoId={paramsVideoId}
@@ -175,6 +163,12 @@
 </div>
 
 <style>
+  .watch-wrapper {
+    margin: 20px 0px 0px 20px;
+    position: relative;
+    width: 100vw;
+    height: calc(100% - 40px);
+  }
   .horizontal {
     flex-direction: column;
   }

--- a/src/components/Watch.svelte
+++ b/src/components/Watch.svelte
@@ -28,7 +28,7 @@
   import Captions from './Captions.svelte';
 
   document.title = 'LiveTL';
-  let isResizing = false;
+  import { isResizing } from '../js/store.js';
   let chatElem, vidElem, ltlElem;
   const resizable = (selector, info) => {
     j(typeof selector == 'string' ? document.querySelector(selector) : selector).resizable(info);
@@ -40,7 +40,7 @@
     ].forEach(item => {
       const [elem, prop, store] = item;
       if (!elem) return;
-      if (isResizing) {
+      if ($isResizing) {
         // elem.style.width = elem.clientWidth;
         // elem.style.height = elem.clientHeight;
       } else {
@@ -60,7 +60,7 @@
   let chatSideElem;
 
   const resizeCallback = () => {
-    isResizing = !isResizing;
+    $isResizing = !$isResizing;
     convertPxAndPercent();
   };
   const changeSide = () => {
@@ -119,7 +119,7 @@
             : ''}"
           bind:this={vidElem}
         >
-          <Wrapper {isResizing}>
+          <Wrapper>
             <VideoEmbed videoId={paramsVideoId} />
           </Wrapper>
         </div>
@@ -148,7 +148,6 @@
             bind:this={chatElem}
           >
             <Wrapper
-              {isResizing}
               zoom={$chatZoom}
               style={$chatSplit == ChatSplit.VERTICAL
                 ? 'padding-right: 10px;'
@@ -162,7 +161,7 @@
             </Wrapper>
           </div>
           <div class="tile autoscale" bind:this={ltlElem}>
-            <Popout {isResizing} />
+            <Popout />
           </div>
         </div>
       </div>

--- a/src/components/Watch.svelte
+++ b/src/components/Watch.svelte
@@ -13,7 +13,8 @@
     chatZoom,
     showCaption,
     chatSplit,
-    displayMode
+    displayMode,
+    isResizing
   } from '../js/store.js';
   import {
     paramsVideoId,
@@ -28,7 +29,6 @@
   import Captions from './Captions.svelte';
 
   document.title = 'LiveTL';
-  import { isResizing } from '../js/store.js';
   let chatElem, vidElem, ltlElem;
   const resizable = (selector, info) => {
     j(typeof selector == 'string' ? document.querySelector(selector) : selector).resizable(info);

--- a/src/components/Watch.svelte
+++ b/src/components/Watch.svelte
@@ -35,8 +35,8 @@
   };
   const convertPxAndPercent = () => {
     [
-      [chatElem, $chatSplit == ChatSplit.VERTICAL ? 'width' : 'height', chatSize],
-      [$displayMode === DisplayMode.FULLPAGE ? vidElem : null, $videoSide == VideoSide.TOP ? 'height' : 'width', videoPanelSize]
+      [chatElem, isChatVertical ? 'width' : 'height', chatSize],
+      [isFullPage ? vidElem : null, isTopSide ? 'height' : 'width', videoPanelSize]
     ].forEach(item => {
       const [elem, prop, store] = item;
       if (!elem) return;
@@ -68,26 +68,32 @@
       elem.remove();
     });
     
-    resizable($videoSide == VideoSide.RIGHT ? chatSideElem : vidElem, {
-      handles: $videoSide == VideoSide.TOP ? 's' : 'e',
+    resizable(isRightSide ? chatSideElem : vidElem, {
+      handles: isTopSide ? 's' : 'e',
       start: resizeCallback,
       stop: resizeCallback,
       resize: (_, dataobj) => {
-        if ($videoSide == VideoSide.RIGHT) {
+        if (isRightSide) {
           $videoPanelSize = Math.min(100, Math.max(0, (1 - (dataobj.size.width / window.innerWidth)) * 100));
         }
       },
       containment: 'body'
     });
     resizable(chatElem, {
-      handles: $chatSplit == ChatSplit.VERTICAL ? 'e' : 's',
+      handles: isChatVertical ? 'e' : 's',
       start: resizeCallback,
       stop: resizeCallback,
       resize: () => {},
       containment: 'body'
     });
   };
-  $: setTimeout(() => changeSide($videoSide, $chatSplit), 0);
+  $: $videoSide, $chatSplit, setTimeout(changeSide, 0);
+
+  $: isRightSide = $videoSide == VideoSide.RIGHT;
+  $: isTopSide = $videoSide == VideoSide.TOP;
+  $: isLeftSide = $videoSide == VideoSide.LEFT;
+  $: isFullPage = $displayMode === DisplayMode.FULLPAGE;
+  $: isChatVertical = $chatSplit == ChatSplit.VERTICAL;
 </script>
 
 <div
@@ -98,23 +104,22 @@
   height: calc(100% - 40px);"
 >
   <MaterialApp theme="dark">
-    {#if $displayMode === DisplayMode.FULLPAGE && $showCaption}
+    {#if isFullPage && $showCaption}
       <Captions />
     {/if}
     <div
       id="mainUI"
       class="flex 
-        {$videoSide == VideoSide.TOP ? 'horizontal' : 'vertical'} 
-        {$videoSide == VideoSide.RIGHT ? 'reversed' : ''}"
+        {isTopSide ? 'horizontal' : 'vertical'} 
+        {isRightSide ? 'reversed' : ''}"
     >
-      {#if $displayMode === DisplayMode.FULLPAGE}
+      {#if isFullPage}
         <div
           class="tile resizable"
-          style="{($videoSide == VideoSide.TOP ? 'height' : `width`) +
-            `: ${$videoPanelSize}%;`}
-            {$videoSide == VideoSide.LEFT
+          style="{(isTopSide ? 'height' : `width`) + `: ${$videoPanelSize}%;`}
+            {isLeftSide
             ? 'min-width: 10px;'
-            : $videoSide == VideoSide.TOP
+            : isTopSide
             ? 'min-height: 10px'
             : ''}"
           bind:this={vidElem}
@@ -127,21 +132,21 @@
       <div
         class="tile autoscale"
         bind:this={chatSideElem}
-        style={$videoSide == VideoSide.TOP ? 'min-width: 100% !important;' : ''}
+        style={isTopSide ? 'min-width: 100% !important;' : ''}
       >
         <div
-          class="flex {$chatSplit == ChatSplit.VERTICAL
+          class="flex {isChatVertical
             ? 'vertical'
             : 'horizontal'}"
           style="
-            {$videoSide == VideoSide.RIGHT ? 'width: calc(100% - 10px);' : ''}"
+            {isRightSide ? 'width: calc(100% - 10px);' : ''}"
         >
           <div
             class="tile resizable"
-            style="{$chatSplit == ChatSplit.VERTICAL
+            style="{isChatVertical
               ? 'width'
               : 'height'}: {$chatSize}%;
-                min-{$chatSplit == ChatSplit.VERTICAL
+                min-{isChatVertical
               ? 'width'
               : 'height'}: 10px;
             "
@@ -149,7 +154,7 @@
           >
             <Wrapper
               zoom={$chatZoom}
-              style={$chatSplit == ChatSplit.VERTICAL
+              style={isChatVertical
                 ? 'padding-right: 10px;'
                 : 'padding-bottom: 10px;'}
             >

--- a/src/components/Watch.svelte
+++ b/src/components/Watch.svelte
@@ -99,7 +99,7 @@
     isChatVertical ? `width: ${$chatSize}%; min-width: `: `height: ${$chatSize}%; min-height: `
   ) + '10px;';
   $: videoContainerStyle = (
-    (isTopSide ? 'height' : `width`) + `: ${$videoPanelSize}%; ` + 
+    (isTopSide ? 'height' : 'width') + `: ${$videoPanelSize}%; ` + 
     (isLeftSide ? 'min-width: 10px;' : (isTopSide ? 'min-height: 10px;': ''))
   );
   $: chatElemParentStyle = isRightSide ? 'width: calc(100% - 10px);' : '';

--- a/src/components/Watch.svelte
+++ b/src/components/Watch.svelte
@@ -96,7 +96,7 @@
   $: isChatVertical = $chatSplit == ChatSplit.VERTICAL;
 
   $: chatElemStyle = (
-    isChatVertical ? `width: ${$chatSize}%; min-width: `: `height: ${chatSize}%; min-height: `
+    isChatVertical ? `width: ${$chatSize}%; min-width: `: `height: ${$chatSize}%; min-height: `
   ) + '10px;';
   $: videoContainerStyle = (
     (isTopSide ? 'height' : `width`) + `: ${$videoPanelSize}%; ` + 

--- a/src/components/Watch.svelte
+++ b/src/components/Watch.svelte
@@ -13,6 +13,7 @@
     chatZoom,
     showCaption,
     chatSplit,
+    displayMode
   } from '../js/store.js';
   import {
     paramsVideoId,
@@ -20,7 +21,7 @@
     ChatSplit,
     paramsContinuation,
     paramsIsVOD,
-    paramsEmbedded
+    DisplayMode
   } from '../js/constants.js';
   import ChatEmbed from './ChatEmbed.svelte';
   import Popout from './Popout.svelte';
@@ -35,7 +36,7 @@
   const convertPxAndPercent = () => {
     [
       [chatElem, $chatSplit == ChatSplit.VERTICAL ? 'width' : 'height', chatSize],
-      [paramsEmbedded ? null : vidElem, $videoSide == VideoSide.TOP ? 'height' : 'width', videoPanelSize]
+      [$displayMode === DisplayMode.FULLPAGE ? vidElem : null, $videoSide == VideoSide.TOP ? 'height' : 'width', videoPanelSize]
     ].forEach(item => {
       const [elem, prop, store] = item;
       if (!elem) return;
@@ -97,7 +98,7 @@
   height: calc(100% - 40px);"
 >
   <MaterialApp theme="dark">
-    {#if !paramsEmbedded && $showCaption}
+    {#if $displayMode === DisplayMode.FULLPAGE && $showCaption}
       <Captions />
     {/if}
     <div
@@ -106,7 +107,7 @@
         {$videoSide == VideoSide.TOP ? 'horizontal' : 'vertical'} 
         {$videoSide == VideoSide.RIGHT ? 'reversed' : ''}"
     >
-      {#if !paramsEmbedded}
+      {#if $displayMode === DisplayMode.FULLPAGE}
         <div
           class="tile resizable"
           style="{($videoSide == VideoSide.TOP ? 'height' : `width`) +

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -1,7 +1,7 @@
 <script>
   import { delayed } from '../js/utils.js';
 
-  export let isResizing;
+  import { isResizing } from '../js/store.js';
   export let zoom = NaN;
   export let style = '';
   let factor;
@@ -22,7 +22,7 @@
 
 <div
   style="
-    display: {isResizing
+    display: {$isResizing
     ? 'none'
     : 'grid'};
     width: {inverse}%;

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -18,13 +18,13 @@
   );
 
   export const isAtTop = delayed(() => div.scrollTop === 0, true);
+
+  $: displayProperty = $isResizing ? 'none' : 'grid';
 </script>
 
 <div
   style="
-    display: {$isResizing
-    ? 'none'
-    : 'grid'};
+    display: {displayProperty};
     width: {inverse}%;
     height: {inverse}%;
     transform-origin: 0px 0px;

--- a/src/components/settings/UISettings.svelte
+++ b/src/components/settings/UISettings.svelte
@@ -37,7 +37,7 @@
     options={Object.keys(TextDirection)}
     store={textDirection}
   />
-  {#if $displayMode !== DisplayMode.POPOUT}
+  {#if $displayMode === DisplayMode.FULLPAGE}
     <EnumOption
       name="Video side:"
       options={Object.keys(VideoSide)}
@@ -49,8 +49,6 @@
         store={autoVertical}
       />
     </div>
-  {/if}
-  {#if $displayMode === DisplayMode.FULLPAGE}
     <EnumOption
       name="Chat split:"
       options={Object.keys(ChatSplit)}
@@ -59,29 +57,29 @@
   {/if}
 </div>
 <CheckOption name="Show timestamps" store={showTimestamp} />
-{#if $displayMode !== DisplayMode.POPOUT}
+{#if $displayMode === DisplayMode.FULLPAGE}
   <CheckOption name="Show captions" store={showCaption} />
-{/if}
-{#if $showCaption}
-  <SliderOption
-    name="Caption font size"
-    store={captionFontSize}
-    min={9}
-    max={54}
-    thumb
-  />
-  <CheckOption
-    name="Make captions disappear when inactive"
-    store={enableCaptionTimeout}
-  />
-  {#if $enableCaptionTimeout}
+  {#if $showCaption}
     <SliderOption
-      name="Disappear after (seconds)"
-      store={captionDuration}
-      min={1}
-      max={61}
+      name="Caption font size"
+      store={captionFontSize}
+      min={9}
+      max={54}
       thumb
     />
+    <CheckOption
+      name="Make captions disappear when inactive"
+      store={enableCaptionTimeout}
+    />
+    {#if $enableCaptionTimeout}
+      <SliderOption
+        name="Disappear after (seconds)"
+        store={captionDuration}
+        min={1}
+        max={61}
+        thumb
+      />
+    {/if}
   {/if}
 {/if}
 <!-- {/if} -->

--- a/src/components/settings/UISettings.svelte
+++ b/src/components/settings/UISettings.svelte
@@ -14,15 +14,15 @@
     chatSplit,
     enableExportButtons,
     enableFullscreenButton,
-    autoVertical
+    autoVertical,
+    displayMode
   } from '../../js/store.js';
-  import { ChatSplit, TextDirection, VideoSide, paramsEmbedded } from '../../js/constants.js';
+  import { ChatSplit, TextDirection, VideoSide, DisplayMode } from '../../js/constants.js';
   import CheckOption from '../options/Toggle.svelte';
   import SliderOption from '../options/Slider.svelte';
   import EnumOption from '../options/Radio.svelte';
   import FontDemo from '../FontDemo.svelte';
   import ImportExport from '../ImportExport.svelte';
-  export let isStandalone = false;
 </script>
 
 <ImportExport />
@@ -37,7 +37,7 @@
     options={Object.keys(TextDirection)}
     store={textDirection}
   />
-  {#if !isStandalone}
+  {#if $displayMode !== DisplayMode.POPOUT}
     <EnumOption
       name="Video side:"
       options={Object.keys(VideoSide)}
@@ -50,7 +50,7 @@
       />
     </div>
   {/if}
-  {#if !isStandalone || paramsEmbedded}
+  {#if $displayMode === DisplayMode.FULLPAGE}
     <EnumOption
       name="Chat split:"
       options={Object.keys(ChatSplit)}
@@ -59,7 +59,7 @@
   {/if}
 </div>
 <CheckOption name="Show timestamps" store={showTimestamp} />
-{#if !isStandalone}
+{#if $displayMode !== DisplayMode.POPOUT}
   <CheckOption name="Show captions" store={showCaption} />
 {/if}
 {#if $showCaption}

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -21,6 +21,13 @@ export const TextDirection = {
   BOTTOM: 'BOTTOM'
 };
 
+/** @enum {String} */
+export const DisplayMode = {
+  POPOUT: 'POPOUT',
+  EMBEDDED: 'EMBEDDED',
+  FULLPAGE: 'FULLPAGE'
+};
+
 // Js enum omegalul
 /** @enum {number} */
 export const Browser = {

--- a/src/js/pages/options.js
+++ b/src/js/pages/options.js
@@ -1,4 +1,8 @@
 import App from '../../components/BrowserAction.svelte';
+import { displayMode } from '../store.js';
+import { DisplayMode } from '../constants.js';
+
+displayMode.set(DisplayMode.POPOUT);
 
 const app = new App({
   target: document.body,

--- a/src/js/pages/popout.js
+++ b/src/js/pages/popout.js
@@ -1,9 +1,12 @@
 import App from '../../components/Popout.svelte';
+import { displayMode } from '../store.js';
+import { DisplayMode } from '../constants.js';
+
+displayMode.set(DisplayMode.POPOUT);
 
 const app = new App({
   target: document.body,
   props: {
-    isStandalone: true
   }
 });
 

--- a/src/js/pages/welcome.js
+++ b/src/js/pages/welcome.js
@@ -3,7 +3,6 @@ import App from '../../components/Welcome.svelte';
 const app = new App({
   target: document.body,
   props: {
-    isStandalone: true
   }
 });
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,4 +1,4 @@
-import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour } from './constants.js';
+import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour, DisplayMode, paramsEmbedded } from './constants.js';
 import { LookupStore, SyncStore } from './storage.js';
 import { writable, readable, derived, Readable } from 'svelte/store';
 import { compose } from './utils.js';
@@ -98,3 +98,4 @@ export const timestamp = writable(0);
 export const faviconURL = writable('/48x48.png');
 export const availableMchadUsers = writable([]);
 export const spotlightedTranslator = writable(null);
+export const displayMode = writable(paramsEmbedded ? DisplayMode.EMBEDDED : DisplayMode.FULLPAGE);

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -99,3 +99,4 @@ export const faviconURL = writable('/48x48.png');
 export const availableMchadUsers = writable([]);
 export const spotlightedTranslator = writable(null);
 export const displayMode = writable(paramsEmbedded ? DisplayMode.EMBEDDED : DisplayMode.FULLPAGE);
+export const isResizing = writable(false);


### PR DESCRIPTION
Replaced `isStandalone` and `paramsEmbedded` usages with a `displayMode` store. This would be helpful for conditionals in the upcoming holodex implementation, where we can just add a new `DisplayMode.HOLODEX` enum