### PR TITLE
Duplication check uses epoch ms

### DIFF
--- a/src/js/sources-util.js
+++ b/src/js/sources-util.js
@@ -20,23 +20,9 @@ export function removeDuplicateMessages(msgs, sourceLatency=10) {
   return msgs.filter(Boolean).filter(isUnique);
 }
 
-/** @type {(msg: Message) => Seconds} */
-const messageTime = msg => {
-  const timeSegments = msg.timestamp.split(':').map(m => parseInt(m));
-  if (timeSegments.length === 3) {
-    const [hours, minutes, seconds] = timeSegments;
-    return hours * 3600 + minutes * 60 + seconds;
-  }
-  if (timeSegments.length === 2) {
-    const [minutes, seconds] = timeSegments;
-    return minutes * 60 + seconds;
-  }
-  throw new Error('Invalid timestamp format');
-};
-
 /** @type {(mostRecent: Message, latency: Number) => (msg: Message) => Boolean} */
 const isRecentMessage = (mostRecent, latency) => msg =>
-  messageTime(mostRecent) - messageTime(msg) <= latency;
+  (mostRecent.timestampMs / 1000) - (msg.timestampMs / 1000) <= latency;
 
 /** @type {(msg: Message) => (otherMsg: Message) => Boolean} */
 const isDuplicateOf = msg => otherMsg =>

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -99,7 +99,8 @@ function ytcToMsg(ytcMessage) {
     authorId: author.id,
     types: typeFlag,
     messageArray: ytcMessage.message,
-    messageId: ytcMessage.messageId
+    messageId: ytcMessage.messageId,
+    timestampMs: ytcMessage.showtime
   };
 }
 

--- a/src/js/types.js
+++ b/src/js/types.js
@@ -2,7 +2,7 @@
 /** @typedef {{type: 'link', url: String, text: String}} LinkMessage */
 /** @typedef {{type: 'emote', src: String}} EmoteMessage */
 /** @typedef {TextMessage | LinkMessage | EmoteMessage} MessageItem */
-/** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, types: Number, authorId: string, messageId: string}} Message */
+/** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, types: Number, authorId: string, messageId: string, timestampMs: number}} Message */
 
 /** @typedef {Number} Seconds */
 /** @typedef {Number} UnixTimestamp */


### PR DESCRIPTION
Fixes #305.

At some point we should probably agree on the same locale to format timestamps for consistency.

Current timestamp locale/format:

Source | Live stream | VOD | Notes
---|---|---|---
YTC | en-GB (HH:MM:SS) | MM:SS and HH:MM:SS | Livestream timestamp used to be based on user locale. VOD timestamp is taken directly from the JSON
Mchad | en-US (HH:MM AM/PM) | HH:MM:SS

(PS: #305 only affects live streams, so I'm waiting for Taishi's next TL session to test this fix there. It works on VODs tho)