### PR TITLE
Duplication check uses epoch ms

### DIFF
--- a/src/__tests__/js/sources-util.js
+++ b/src/__tests__/js/sources-util.js
@@ -4,11 +4,11 @@ import { removeDuplicateMessages } from '../../js/sources-util.js';
 import { AuthorType } from '../../js/constants.js';
 
 
-const message = (text, author, timestamp, types) => ({
+const message = (text, author, timestampMs, types) => ({
   text,
   messageArray: [{ type: 'text', text }],
   author,
-  timestamp,
+  timestampMs,
   id: '9',
   types
 });
@@ -17,9 +17,9 @@ const message = (text, author, timestamp, types) => ({
 describe('message duplication mitigation', () =>{ 
   it('filters duplicate messages from another source within the past 10 seconds', () => {
     const messages = [
-      message('Konichiwassup', 'Taishi', '00:10:00', AuthorType.mchad),
-      message('hello there', 'Taishi', '00:10:12',  AuthorType.mchad),
-      message('hello there', 'Taishi Ch.', '10:15', 0),
+      message('Konichiwassup', 'Taishi', 100000, AuthorType.mchad),
+      message('hello there', 'Taishi', 112000,  AuthorType.mchad),
+      message('hello there', 'Taishi Ch.', 115000, 0),
     ];
     const expectedMessages = [
       messages[0],
@@ -31,11 +31,11 @@ describe('message duplication mitigation', () =>{
   // test case is based off a situation that happened
   it('catches cases of duplicates where there are messages sent in between', () => {
     const messages = [
-      message('Haachama: *eats spider', 'Taishi', '00:10:14', AuthorType.mchad),
-      message('Cook me and eat me Haachama pls', 'Shrek Wazowski', '10:15', 0),
-      message('Haachama: *enlightened noises', 'Taishi', '00:10:18', AuthorType.mchad),
-      message('Haachama: *eats spider', 'Taishi ch.', '00:10:20', 0),
-      message('Haachama: *enlightened noises', 'Taishi ch.', '10:25', 0),
+      message('Haachama: *eats spider', 'Taishi', 114000, AuthorType.mchad),
+      message('Cook me and eat me Haachama pls', 'Shrek Wazowski', 115000, 0),
+      message('Haachama: *enlightened noises', 'Taishi', 118000, AuthorType.mchad),
+      message('Haachama: *eats spider', 'Taishi ch.', 120000, 0),
+      message('Haachama: *enlightened noises', 'Taishi ch.', 125000, 0),
     ];
     const expectedMessages = [
       messages[0],
@@ -48,33 +48,33 @@ describe('message duplication mitigation', () =>{
   // needed for repeated tls like '*explains meme' with other tls in between
   it('lets messages that are duplicates of a message outside of the last 10 seconds through', () => {
     const messages = [
-      message('Konichiwassup', 'Taishi', '00:10:00', AuthorType.mchad),
-      message('hello there', 'Taishi Ch.', '10:05',  0),
-      message('Konichiwassup', 'Taishi', '00:10:12', AuthorType.mchad),
-      message('hello there', 'Taishi Ch.', '10:18', 0),
-      message('Konichiwassup', 'Taishi Ch.', '10:30', 0),
-      message('hello there', 'Taishi', '00:10:40', AuthorType.mchad),
+      message('Konichiwassup', 'Taishi', 100000, AuthorType.mchad),
+      message('hello there', 'Taishi Ch.', 105000,  0),
+      message('Konichiwassup', 'Taishi', 112000, AuthorType.mchad),
+      message('hello there', 'Taishi Ch.', 118000, 0),
+      message('Konichiwassup', 'Taishi Ch.', 130000, 0),
+      message('hello there', 'Taishi', 140000, AuthorType.mchad),
     ];
     expect(removeDuplicateMessages(messages)).toEqual(messages);
   });
 
   it('lets non-duplicate messages of same source through', () => {
     const messages = [
-      message('Konichiwassup', 'Taishi', '00:10:00', 0),
-      message('hello there', 'Taishi Ch.', '10:05',  0),
-      message('good translation', 'Taishi', '00:10:12', 0),
-      message('another good translation', 'Taishi Ch.', '10:18', 0),
-      message('puhehehe', 'Taishi Ch.', '10:30', 0),
-      message('hehe', 'Taishi', '00:10:40', 0),
+      message('Konichiwassup', 'Taishi', 100000, 0),
+      message('hello there', 'Taishi Ch.', 105000,  0),
+      message('good translation', 'Taishi', 112000, 0),
+      message('another good translation', 'Taishi Ch.', 118000, 0),
+      message('puhehehe', 'Taishi Ch.', 130000, 0),
+      message('hehe', 'Taishi', 140000, 0),
     ];
     expect(removeDuplicateMessages(messages)).toEqual(messages);
   });
 
   it('admits duplicate messages of inside the last 10 seconds and from same source', () => {
     const messages = [
-      message('*Explains meme', 'Taishi', '00:10:00', AuthorType.mchad),
-      message('*Explains meme', 'Taishi Ch.', '10:05', 0),
-      message('*Explains meme', 'Taishi', '00:10:08', AuthorType.mchad),
+      message('*Explains meme', 'Taishi', 100000, AuthorType.mchad),
+      message('*Explains meme', 'Taishi Ch.', 105000, 0),
+      message('*Explains meme', 'Taishi', 108000, AuthorType.mchad),
     ];
     const expectedMessages = [
       messages[0],
@@ -85,9 +85,9 @@ describe('message duplication mitigation', () =>{
 
   it('lets non-duplicate messages through', () => {
     const messages = [
-      message('Hey there', 'Taishi', '00:19:20', AuthorType.mchad),
-      message('Hello there', 'Taishi Ch.', '00:19:22', 0),
-      message('Konichiwassup', 'Shrek Wazowski', '00:20:00', 0),
+      message('Hey there', 'Taishi', 120000, AuthorType.mchad),
+      message('Hello there', 'Taishi Ch.', 100000, 0),
+      message('Konichiwassup', 'Shrek Wazowski', 200000, 0),
     ];
     expect(removeDuplicateMessages(messages)).toEqual(messages);
   });

--- a/src/js/sources-util.js
+++ b/src/js/sources-util.js
@@ -20,23 +20,9 @@ export function removeDuplicateMessages(msgs, sourceLatency=10) {
   return msgs.filter(Boolean).filter(isUnique);
 }
 
-/** @type {(msg: Message) => Seconds} */
-const messageTime = msg => {
-  const timeSegments = msg.timestamp.split(':').map(m => parseInt(m));
-  if (timeSegments.length === 3) {
-    const [hours, minutes, seconds] = timeSegments;
-    return hours * 3600 + minutes * 60 + seconds;
-  }
-  if (timeSegments.length === 2) {
-    const [minutes, seconds] = timeSegments;
-    return minutes * 60 + seconds;
-  }
-  throw new Error('Invalid timestamp format');
-};
-
 /** @type {(mostRecent: Message, latency: Number) => (msg: Message) => Boolean} */
 const isRecentMessage = (mostRecent, latency) => msg =>
-  messageTime(mostRecent) - messageTime(msg) <= latency;
+  (mostRecent.timestampMs / 1000) - (msg.timestampMs / 1000) <= latency;
 
 /** @type {(msg: Message) => (otherMsg: Message) => Boolean} */
 const isDuplicateOf = msg => otherMsg =>

--- a/src/js/sources-util.js
+++ b/src/js/sources-util.js
@@ -20,9 +20,12 @@ export function removeDuplicateMessages(msgs, sourceLatency=10) {
   return msgs.filter(Boolean).filter(isUnique);
 }
 
+/** @type {(msg: Message) => Seconds} */
+const messageTime = msg => msg.timestampMs / 1000;
+
 /** @type {(mostRecent: Message, latency: Number) => (msg: Message) => Boolean} */
 const isRecentMessage = (mostRecent, latency) => msg =>
-  (mostRecent.timestampMs / 1000) - (msg.timestampMs / 1000) <= latency;
+  messageTime(mostRecent) - messageTime(msg) <= latency;
 
 /** @type {(msg: Message) => (otherMsg: Message) => Boolean} */
 const isDuplicateOf = msg => otherMsg =>

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -99,7 +99,8 @@ function ytcToMsg(ytcMessage) {
     authorId: author.id,
     types: typeFlag,
     messageArray: ytcMessage.message,
-    messageId: ytcMessage.messageId
+    messageId: ytcMessage.messageId,
+    timestampMs: ytcMessage.showtime
   };
 }
 

--- a/src/js/types.js
+++ b/src/js/types.js
@@ -2,7 +2,7 @@
 /** @typedef {{type: 'link', url: String, text: String}} LinkMessage */
 /** @typedef {{type: 'emote', src: String}} EmoteMessage */
 /** @typedef {TextMessage | LinkMessage | EmoteMessage} MessageItem */
-/** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, types: Number, authorId: string, messageId: string}} Message */
+/** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, types: Number, authorId: string, messageId: string, timestampMs: number}} Message */
 
 /** @typedef {Number} Seconds */
 /** @typedef {Number} UnixTimestamp */


### PR DESCRIPTION
Originally a PR by Rubin, recreated after a failed merge (since tests were not updated)

Fixes #305.

At some point we should probably agree on the same locale to format timestamps for consistency.

Current timestamp locale/format:

Source | Live stream | VOD | Notes
---|---|---|---
YTC | en-GB (HH:MM:SS) | MM:SS and HH:MM:SS | Livestream timestamp used to be based on user locale. VOD timestamp is taken directly from the JSON
Mchad | en-US (HH:MM AM/PM) | HH:MM:SS

(PS: #305 only affects live streams, so I'm waiting for Taishi's next TL session to test this fix there. It works on VODs tho)