### PR TITLE
Improved speech synth

### DIFF
--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -56,10 +56,7 @@
 <svelte:window on:resize={redrawSlider} />
 
 <MaterialApp theme="dark">
-  <div
-    style="display: flex; align-items: center; justify-content: center;"
-    bind:this={wrapper}
-  >
+  <div class="settings-parent" bind:this={wrapper}>
     <div
       class="settings-container"
       style="max-width: calc(min(500px, 100%)); width: 100%;"
@@ -102,6 +99,13 @@
 </MaterialApp>
 
 <style>
+  .settings-parent {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    height: 100% !important;
+    overflow: hidden;
+  }
   :global(label > .option-label) {
     padding-top: 0px;
     top: 0px;
@@ -116,6 +120,15 @@
   }
   :global(.s-window) {
     padding: 0px 10px 0px 10px;
+    height: 100%;
+  }
+
+  :global(.s-tabs) {
+    height: 100%;
+  }
+
+  .settings-container {
+    height: 100%;
   }
 
   .settings-container :global(.s-tooltip__wrapper) {

--- a/src/components/options/Dropdown.svelte
+++ b/src/components/options/Dropdown.svelte
@@ -5,7 +5,9 @@
   export let store = null;
   export let items = [];
   export let active = false;
-
+  export let label = '';
+  let elem = null;
+  
   function correctValue() {
     if (value == null) {
       value = $store;
@@ -18,6 +20,24 @@
   $: value = $store;
   $: correctValue(value);
   $: store.set(value);
+
+  $: if (label && elem) {
+    setTimeout(() => {
+      elem.querySelector('input').value = label || value;
+    }, 0);
+  }
 </script>
 
-<Select bind:value {items} solo bind:active>{name}</Select>
+<div bind:this={elem}>
+  <Select bind:value {items} solo bind:active>{name}</Select>
+</div>
+
+<style>
+  :global(.s-text-field__input) {
+    display: flex;
+    align-items: center;
+  }
+  :global(.s-text-field__input label) {
+    top: unset !important;
+  }
+</style>

--- a/src/components/options/Dropdown.svelte
+++ b/src/components/options/Dropdown.svelte
@@ -41,16 +41,16 @@
   $: active, setTimeout(() => windowResized($windowSize), 0);
 </script>
 
-<div bind:this={elem}>
+<div bind:this={elem} class="wrapped">
   <Select bind:value {items} solo bind:active>{name}</Select>
 </div>
 
 <style>
-  :global(.s-text-field__input) {
+  .wrapped :global(.s-text-field__input) {
     display: flex;
     align-items: center;
   }
-  :global(.s-text-field__input label) {
+  .wrapped :global(.s-text-field__input label) {
     top: unset !important;
   }
 </style>

--- a/src/components/options/Dropdown.svelte
+++ b/src/components/options/Dropdown.svelte
@@ -32,7 +32,7 @@
     if (elem) {
       const list = elem.querySelector('.s-menu');
       if (list) {
-        const bounds = list.getBoundingClientRect()
+        const bounds = list.getBoundingClientRect();
         list.style.height = `${Math.min(bounds.height, size.height - bounds.y)}px`;
       }
     }

--- a/src/components/options/Dropdown.svelte
+++ b/src/components/options/Dropdown.svelte
@@ -1,5 +1,6 @@
 <script>
   import { Select } from 'svelte-materialify/src';
+  import { windowSize } from '../../js/store.js';
 
   export let name = '';
   export let store = null;
@@ -26,6 +27,18 @@
       elem.querySelector('input').value = label || value;
     }, 0);
   }
+
+  function windowResized(size) {
+    if (elem) {
+      const list = elem.querySelector('.s-menu');
+      if (list) {
+        const bounds = list.getBoundingClientRect()
+        list.style.height = `${Math.min(bounds.height, size.height - bounds.y)}px`;
+      }
+    }
+  }
+  
+  $: active, setTimeout(() => windowResized($windowSize), 0);
 </script>
 
 <div bind:this={elem}>

--- a/src/components/options/ReadAloud.svelte
+++ b/src/components/options/ReadAloud.svelte
@@ -24,7 +24,7 @@
 <CheckOption name="Read-aloud mode" store={doSpeechSynth} />
 {#if $doSpeechSynth}
   <SliderOption name="Speech volume" store={speechVolume} min={0} max={1} />
-  <SliderOption name="Speech speed" store={speechSpeed} min={0.5} max={2} />
+  <SliderOption name="Speech speed" store={speechSpeed} min={0.5} max={2} thumb={Math.round($speechSpeed * 10)/10} />
   <Dropdown
     name="Speech synthesis voice"
     label={$speechVoiceName || 'Loading voices...'}

--- a/src/components/options/ReadAloud.svelte
+++ b/src/components/options/ReadAloud.svelte
@@ -1,0 +1,43 @@
+<script>
+  import {
+    doSpeechSynth,
+    speechVoiceName,
+    speechSpeed,
+    speechVolume
+  } from '../../js/store.js';
+  import { getAllVoiceNames } from '../../js/utils.js';
+  import CheckOption from '../options/Toggle.svelte';
+  import SliderOption from '../options/Slider.svelte';
+  import Dropdown from '../options/Dropdown.svelte';
+  import { writable } from 'svelte/store';
+  import { onMount, onDestroy } from 'svelte';
+
+  const store = writable(0);
+  const voiceNames = getAllVoiceNames();
+  const selectableLanguages = voiceNames.map((n, i) => ({
+    name: n,
+    value: i
+  }));
+  /**
+  * @type {any[]}
+  */
+  let subs = [];
+  onMount(() => {
+    subs = [
+      store.subscribe(v => $speechVoiceName = voiceNames[v]),
+      speechVoiceName.subscribe(v => {
+        $store = parseInt(selectableLanguages.find(l => l.name == v)?.value || '0'); 
+      })
+    ];
+  });
+  onDestroy(() => {
+    subs.forEach(s => s());
+  });
+</script>
+
+<CheckOption name="Read-aloud mode" store={doSpeechSynth} />
+{#if $doSpeechSynth}
+  <SliderOption name="Speech volume" store={speechVolume} min={0} max={1} />
+  <SliderOption name="Speech speed" store={speechSpeed} min={0.5} max={2} />
+  <Dropdown name="Voice" {store} items={selectableLanguages} />
+{/if}

--- a/src/components/options/ReadAloud.svelte
+++ b/src/components/options/ReadAloud.svelte
@@ -14,9 +14,9 @@
 
   const store = writable('0');
   $: selectableLanguages = $voiceNames.map((n, i) => ({
-      name: n,
-      value: i.toString()
-    }));
+    name: n,
+    value: i.toString()
+  }));
   $: store.set(selectableLanguages.find(l => l.name == $speechVoiceName)?.value || '0');
   $: speechVoiceNameSetting.set($voiceNames[$store]);
 </script>

--- a/src/components/options/ReadAloud.svelte
+++ b/src/components/options/ReadAloud.svelte
@@ -2,6 +2,7 @@
   import {
     doSpeechSynth,
     speechVoiceName,
+    speechVoiceNameSetting,
     speechSpeed,
     speechVolume,
     voiceNames
@@ -17,7 +18,7 @@
       value: i.toString()
     }));
   $: store.set(selectableLanguages.find(l => l.name == $speechVoiceName)?.value || '0');
-  $: speechVoiceName.set($voiceNames[$store]);
+  $: speechVoiceNameSetting.set($voiceNames[$store]);
 </script>
 
 <CheckOption name="Read-aloud mode" store={doSpeechSynth} />
@@ -26,7 +27,7 @@
   <SliderOption name="Speech speed" store={speechSpeed} min={0.5} max={2} />
   <Dropdown
     name="Speech synthesis voice"
-    label={$speechVoiceName}
+    label={$speechVoiceName || 'Loading voices...'}
     {store}
     items={selectableLanguages}
   />

--- a/src/components/options/ReadAloud.svelte
+++ b/src/components/options/ReadAloud.svelte
@@ -10,20 +10,24 @@
   import SliderOption from '../options/Slider.svelte';
   import Dropdown from '../options/Dropdown.svelte';
   import { writable } from 'svelte/store';
-  import { onMount, onDestroy } from 'svelte';
 
   const store = writable('0');
   $: selectableLanguages = $voiceNames.map((n, i) => ({
       name: n,
       value: i.toString()
     }));
-  $: speechVoiceName.set($voiceNames[$store]);
   $: store.set(selectableLanguages.find(l => l.name == $speechVoiceName)?.value || '0');
+  $: speechVoiceName.set($voiceNames[$store]);
 </script>
 
 <CheckOption name="Read-aloud mode" store={doSpeechSynth} />
 {#if $doSpeechSynth}
   <SliderOption name="Speech volume" store={speechVolume} min={0} max={1} />
   <SliderOption name="Speech speed" store={speechSpeed} min={0.5} max={2} />
-  <Dropdown name="Speech synthesis voice" label={$speechVoiceName} {store} items={selectableLanguages} />
+  <Dropdown
+    name="Speech synthesis voice"
+    label={$speechVoiceName}
+    {store}
+    items={selectableLanguages}
+  />
 {/if}

--- a/src/components/options/ReadAloud.svelte
+++ b/src/components/options/ReadAloud.svelte
@@ -3,41 +3,27 @@
     doSpeechSynth,
     speechVoiceName,
     speechSpeed,
-    speechVolume
+    speechVolume,
+    voiceNames
   } from '../../js/store.js';
-  import { getAllVoiceNames } from '../../js/utils.js';
   import CheckOption from '../options/Toggle.svelte';
   import SliderOption from '../options/Slider.svelte';
   import Dropdown from '../options/Dropdown.svelte';
   import { writable } from 'svelte/store';
   import { onMount, onDestroy } from 'svelte';
 
-  const store = writable(0);
-  const voiceNames = getAllVoiceNames();
-  const selectableLanguages = voiceNames.map((n, i) => ({
-    name: n,
-    value: i
-  }));
-  /**
-  * @type {any[]}
-  */
-  let subs = [];
-  onMount(() => {
-    subs = [
-      store.subscribe(v => $speechVoiceName = voiceNames[v]),
-      speechVoiceName.subscribe(v => {
-        $store = parseInt(selectableLanguages.find(l => l.name == v)?.value || '0'); 
-      })
-    ];
-  });
-  onDestroy(() => {
-    subs.forEach(s => s());
-  });
+  const store = writable('0');
+  $: selectableLanguages = $voiceNames.map((n, i) => ({
+      name: n,
+      value: i.toString()
+    }));
+  $: speechVoiceName.set($voiceNames[$store]);
+  $: store.set(selectableLanguages.find(l => l.name == $speechVoiceName)?.value || '0');
 </script>
 
 <CheckOption name="Read-aloud mode" store={doSpeechSynth} />
 {#if $doSpeechSynth}
   <SliderOption name="Speech volume" store={speechVolume} min={0} max={1} />
   <SliderOption name="Speech speed" store={speechSpeed} min={0.5} max={2} />
-  <Dropdown name="Voice" {store} items={selectableLanguages} />
+  <Dropdown name="Speech synthesis voice" label={$speechVoiceName} {store} items={selectableLanguages} />
 {/if}

--- a/src/components/options/Slider.svelte
+++ b/src/components/options/Slider.svelte
@@ -69,7 +69,7 @@
 </script>
 
 <div bind:this={wrapper}>
-  <Slider bind:value {color} {step} thumb={thumb ? true : false}>
+  <Slider bind:value {color} {step} thumb={Boolean(thumb)}>
     <div slot="default">
       {name}{suffix}
     </div>

--- a/src/components/options/Slider.svelte
+++ b/src/components/options/Slider.svelte
@@ -26,7 +26,7 @@
     if (wrapper == null) return;
     let e = wrapper.querySelector('.s-slider__tooltip');
     if (e) {
-      e.setAttribute('data-content', Math.round(scaledBack));
+      e.setAttribute('data-content', typeof thumb != 'boolean' ? thumb : Math.round(scaledBack));
     }
   }
 
@@ -69,7 +69,7 @@
 </script>
 
 <div bind:this={wrapper}>
-  <Slider bind:value {color} {step} {thumb}>
+  <Slider bind:value {color} {step} thumb={thumb ? true : false}>
     <div slot="default">
       {name}{suffix}
     </div>

--- a/src/components/settings/UISettings.svelte
+++ b/src/components/settings/UISettings.svelte
@@ -5,10 +5,8 @@
     videoSideSetting,
     chatZoom,
     livetlFontSize,
-    doSpeechSynth,
     showCaption,
     showTimestamp,
-    speechVolume,
     textDirection,
     enableCaptionTimeout,
     chatSplit,
@@ -16,16 +14,14 @@
     enableFullscreenButton,
     autoVertical,
     displayMode,
-    speechVoice,
-    speechSpeed
   } from '../../js/store.js';
-  import { ChatSplit, TextDirection, VideoSide, DisplayMode, AllVoiceNames } from '../../js/constants.js';
+  import { ChatSplit, TextDirection, VideoSide, DisplayMode } from '../../js/constants.js';
   import CheckOption from '../options/Toggle.svelte';
   import SliderOption from '../options/Slider.svelte';
   import EnumOption from '../options/Radio.svelte';
   import FontDemo from '../FontDemo.svelte';
   import ImportExport from '../ImportExport.svelte';
-  import Dropdown from '../options/Dropdown.svelte';
+  import ReadAloud from '../options/ReadAloud.svelte';
 </script>
 
 <ImportExport />
@@ -86,12 +82,7 @@
   {/if}
 {/if}
 <!-- {/if} -->
-<CheckOption name="Read-aloud mode" store={doSpeechSynth} />
-{#if $doSpeechSynth}
-  <SliderOption name="Speech volume" store={speechVolume} min={0} max={1} />
-  <SliderOption name="Speech speed" store={speechSpeed} min={0.5} max={2} />
-  <Dropdown name="Voice" store={speechVoice} items={AllVoiceNames} />
-{/if}
+<ReadAloud />
 <CheckOption
   name="Show screenshot and download buttons"
   store={enableExportButtons}

--- a/src/components/settings/UISettings.svelte
+++ b/src/components/settings/UISettings.svelte
@@ -15,14 +15,17 @@
     enableExportButtons,
     enableFullscreenButton,
     autoVertical,
-    displayMode
+    displayMode,
+    speechVoice,
+    speechSpeed
   } from '../../js/store.js';
-  import { ChatSplit, TextDirection, VideoSide, DisplayMode } from '../../js/constants.js';
+  import { ChatSplit, TextDirection, VideoSide, DisplayMode, AllVoiceNames } from '../../js/constants.js';
   import CheckOption from '../options/Toggle.svelte';
   import SliderOption from '../options/Slider.svelte';
   import EnumOption from '../options/Radio.svelte';
   import FontDemo from '../FontDemo.svelte';
   import ImportExport from '../ImportExport.svelte';
+  import Dropdown from '../options/Dropdown.svelte';
 </script>
 
 <ImportExport />
@@ -86,6 +89,8 @@
 <CheckOption name="Read-aloud mode" store={doSpeechSynth} />
 {#if $doSpeechSynth}
   <SliderOption name="Speech volume" store={speechVolume} min={0} max={1} />
+  <SliderOption name="Speech speed" store={speechSpeed} min={0.5} max={2} />
+  <Dropdown name="Voice" store={speechVoice} items={AllVoiceNames} />
 {/if}
 <CheckOption
   name="Show screenshot and download buttons"

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -109,3 +109,6 @@ export const ytcDeleteValues = new Map([
   [YtcDeleteBehaviour.PLACEHOLDER, 'Show placeholder'],
   [YtcDeleteBehaviour.NOTHING, 'Do nothing']
 ]);
+
+export const AllVoices = speechSynthesis.getVoices();
+export const AllVoiceNames = AllVoices.map(voice => voice.name);

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -109,6 +109,3 @@ export const ytcDeleteValues = new Map([
   [YtcDeleteBehaviour.PLACEHOLDER, 'Show placeholder'],
   [YtcDeleteBehaviour.NOTHING, 'Do nothing']
 ]);
-
-export const AllVoices = speechSynthesis.getVoices();
-export const AllVoiceNames = AllVoices.map(voice => voice.name);

--- a/src/js/speech.js
+++ b/src/js/speech.js
@@ -1,4 +1,4 @@
-import { doSpeechSynth, language, speechVolume, speechVoice, speechSpeed } from './store.js';
+import { doSpeechSynth, language, speechVolume, speechSpeed, speechSpeaker } from './store.js';
 import { languageNameCode } from './constants.js';
 import { get } from 'svelte/store';
 
@@ -6,7 +6,7 @@ export function speak(text, volume=0) {
   // speechSynthesis.cancel();
   const utterance = new SpeechSynthesisUtterance(text);
   utterance.volume = volume || speechVolume.get();
-  utterance.voice = get(speechVoice);
+  utterance.voice = get(speechSpeaker);
   utterance.rate = speechSpeed.get();
   utterance.lang = languageNameCode[language.get()].tag;
   speechSynthesis.speak(utterance);

--- a/src/js/speech.js
+++ b/src/js/speech.js
@@ -1,10 +1,12 @@
-import { doSpeechSynth, language, speechVolume } from './store.js';
-import { languageNameCode } from './constants.js';
+import { doSpeechSynth, language, speechVolume, speechVoice, speechSpeed } from './store.js';
+import { languageNameCode, AllVoices } from './constants.js';
 
 export function speak(text, volume=0) {
   // speechSynthesis.cancel();
   const utterance = new SpeechSynthesisUtterance(text);
   utterance.volume = volume || speechVolume.get();
+  utterance.voice = AllVoices[speechSynthesis.getVoices().find(v => v.name == speechVoice.get())];
+  utterance.rate = speechSpeed.get();
   utterance.lang = languageNameCode[language.get()].tag;
   speechSynthesis.speak(utterance);
 }

--- a/src/js/speech.js
+++ b/src/js/speech.js
@@ -1,11 +1,12 @@
 import { doSpeechSynth, language, speechVolume, speechVoice, speechSpeed } from './store.js';
-import { languageNameCode, AllVoices } from './constants.js';
+import { languageNameCode } from './constants.js';
+import { get } from 'svelte/store';
 
 export function speak(text, volume=0) {
   // speechSynthesis.cancel();
   const utterance = new SpeechSynthesisUtterance(text);
   utterance.volume = volume || speechVolume.get();
-  utterance.voice = AllVoices[speechSynthesis.getVoices().find(v => v.name == speechVoice.get())];
+  utterance.voice = get(speechVoice);
   utterance.rate = speechSpeed.get();
   utterance.lang = languageNameCode[language.get()].tag;
   speechSynthesis.speak(utterance);

--- a/src/js/speech.js
+++ b/src/js/speech.js
@@ -7,7 +7,7 @@ export function speak(text, volume=0) {
   const utterance = new SpeechSynthesisUtterance(text);
   utterance.volume = volume || speechVolume.get();
   utterance.voice = get(speechSpeaker);
-  utterance.rate = speechSpeed.get();
+  utterance.rate = Math.round(speechSpeed.get() * 10)/10;
   utterance.lang = languageNameCode[language.get()].tag;
   speechSynthesis.speak(utterance);
 }
@@ -23,8 +23,12 @@ setTimeout(() => {
   doSpeechSynth.subscribe($doSpeechSynth => {
     if (isInitial || !$doSpeechSynth) {
       isInitial = false;
+      speechSynthesis.cancel();
       return;
     }
     speak('Speech synthesis enabled');
+  });
+  speechSpeaker.subscribe(_$speechSpeaker => {
+    speechSynthesis.cancel();
   });
 }, 0);

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,4 +1,4 @@
-import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour, DisplayMode, paramsEmbedded } from './constants.js';
+import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour, DisplayMode, paramsEmbedded, AllVoiceNames } from './constants.js';
 import { LookupStore, SyncStore } from './storage.js';
 // eslint-disable-next-line no-unused-vars
 import { writable, readable, derived, Readable } from 'svelte/store';
@@ -81,7 +81,9 @@ export const
   enableSpamProtection = SS('enableSpamProtection', true),
   spamMsgAmount = SS('spamMsgAmount', 5),
   spamMsgInterval = SS('spamMsgInterval', 10),
-  spammersDetected = LS('spammersDetected', [sampleSpam].slice(1));
+  spammersDetected = LS('spammersDetected', [sampleSpam].slice(1)),
+  speechVoice = SS('speechVoice', AllVoiceNames[0]),
+  speechSpeed = SS('speechSpeed', 1);
 
 // Non-persistant stores
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -110,14 +110,10 @@ export const voiceNames = readable(getAllVoiceNames(), set => {
   window.addEventListener('load', cb);
   return unsub;
 });
-export const speechSpeaker = readable(getVoiceMap()[speechVoiceName.get()], set => {
-  const cb = () => set(getVoiceMap().get(speechVoiceName.get()));
-  const unsub = [
-    speechVoiceName.subscribe(cb),
-    voiceNames.subscribe(cb)
-  ];
-  return unsub.forEach(u => u());
-});
+export const speechSpeaker = derived(
+  [speechVoiceName, voiceNames],
+  ([$speechVoiceName, _$voiceNames]) => getVoiceMap().get($speechVoiceName),
+);
 
 export const updatePopupActive = writable(false);
 export const videoTitle = writable('LiveTL');

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -101,15 +101,24 @@ export const videoSide = derived(videoSideDepends, ([$videoSide, $autoVert, $win
   const { width, height } = $windims;
   return $autoVert && height > width ? VideoSide.TOP : $videoSide;
 }, videoSideSetting.get());
-export const speechVoice = readable(undefined, set => {
+export const voiceNames = readable(getAllVoiceNames(), set => {
+  const cb = () => set(getAllVoiceNames());
+  window.addEventListener('load', cb);
+  return () => window.removeEventListener('load', cb);
+});
+export const speechVoice = readable(getAllVoiceNames()[0], set => {
   const cb = () => set(getAllVoiceNames()[0]);
   window.addEventListener('load', cb);
-  const unsub = speechVoiceName.subscribe(() => set(getVoiceMap()[speechVoiceName.get()]));
+  const unlisten = () => window.removeEventListener('load', cb);
+  const unsub = speechVoiceName.subscribe(() => {
+    set(getVoiceMap()[speechVoiceName.get()]);
+    unlisten();
+  });
   return () => {
-    window.removeEventListener('load', cb);
+    unlisten();
     unsub();
   };
-}); 
+});
 
 export const updatePopupActive = writable(false);
 export const videoTitle = writable('LiveTL');

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -83,7 +83,7 @@ export const
   spamMsgAmount = SS('spamMsgAmount', 5),
   spamMsgInterval = SS('spamMsgInterval', 10),
   spammersDetected = LS('spammersDetected', [sampleSpam].slice(1)),
-  speechVoiceName = SS('speechVoiceName', ''),
+  speechVoiceNameSetting = SS('speechVoiceNameSetting', ''),
   speechSpeed = SS('speechSpeed', 1);
 
 // Non-persistant stores
@@ -110,6 +110,15 @@ export const voiceNames = readable(getAllVoiceNames(), set => {
   window.addEventListener('load', cb);
   return unsub;
 });
+export const speechVoiceName = derived(
+  [speechVoiceNameSetting, voiceNames],
+  ([$speechVoiceNameSetting, $voiceNames]) => {
+    return (
+      $voiceNames.includes($speechVoiceNameSetting) ?
+        $speechVoiceNameSetting : $voiceNames[0]
+    ); 
+  },
+);
 export const speechSpeaker = derived(
   [speechVoiceName, voiceNames],
   ([$speechVoiceName, _$voiceNames]) => getVoiceMap().get($speechVoiceName),

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -102,22 +102,21 @@ export const videoSide = derived(videoSideDepends, ([$videoSide, $autoVert, $win
   return $autoVert && height > width ? VideoSide.TOP : $videoSide;
 }, videoSideSetting.get());
 export const voiceNames = readable(getAllVoiceNames(), set => {
-  const cb = () => set(getAllVoiceNames());
-  window.addEventListener('load', cb);
-  return () => window.removeEventListener('load', cb);
-});
-export const speechVoice = readable(getAllVoiceNames()[0], set => {
-  const cb = () => set(getAllVoiceNames()[0]);
-  window.addEventListener('load', cb);
-  const unlisten = () => window.removeEventListener('load', cb);
-  const unsub = speechVoiceName.subscribe(() => {
-    set(getVoiceMap()[speechVoiceName.get()]);
-    unlisten();
-  });
-  return () => {
-    unlisten();
+  const cb = () => {
+    set(getAllVoiceNames());
     unsub();
   };
+  const unsub = () => window.removeEventListener('load', cb);
+  window.addEventListener('load', cb);
+  return unsub;
+});
+export const speechSpeaker = readable(getVoiceMap()[speechVoiceName.get()], set => {
+  const cb = () => set(getVoiceMap().get(speechVoiceName.get()));
+  const unsub = [
+    speechVoiceName.subscribe(cb),
+    voiceNames.subscribe(cb)
+  ];
+  return unsub.forEach(u => u());
 });
 
 export const updatePopupActive = writable(false);

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,4 +1,5 @@
-import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour, DisplayMode, paramsEmbedded, AllVoiceNames } from './constants.js';
+import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour, DisplayMode, paramsEmbedded } from './constants.js';
+import { getAllVoiceNames, getVoiceMap } from './utils.js';
 import { LookupStore, SyncStore } from './storage.js';
 // eslint-disable-next-line no-unused-vars
 import { writable, readable, derived, Readable } from 'svelte/store';
@@ -82,7 +83,7 @@ export const
   spamMsgAmount = SS('spamMsgAmount', 5),
   spamMsgInterval = SS('spamMsgInterval', 10),
   spammersDetected = LS('spammersDetected', [sampleSpam].slice(1)),
-  speechVoice = SS('speechVoice', AllVoiceNames[0]),
+  speechVoiceName = SS('speechVoiceName', ''),
   speechSpeed = SS('speechSpeed', 1);
 
 // Non-persistant stores
@@ -100,6 +101,15 @@ export const videoSide = derived(videoSideDepends, ([$videoSide, $autoVert, $win
   const { width, height } = $windims;
   return $autoVert && height > width ? VideoSide.TOP : $videoSide;
 }, videoSideSetting.get());
+export const speechVoice = readable(undefined, set => {
+  const cb = () => set(getAllVoiceNames()[0]);
+  window.addEventListener('load', cb);
+  const unsub = speechVoiceName.subscribe(() => set(getVoiceMap()[speechVoiceName.get()]));
+  return () => {
+    window.removeEventListener('load', cb);
+    unsub();
+  };
+}); 
 
 export const updatePopupActive = writable(false);
 export const videoTitle = writable('LiveTL');

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -55,6 +55,6 @@ export const sleep = ms => new Promise((res, _rej) => {
 export const escapeRegExp = text => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
 
-export const getAllVoices = () => speechSynthesis.getVoices();
+export const getAllVoices = () => window.speechSynthesis.getVoices();
 export const getAllVoiceNames = () => getAllVoices().map(voice => voice.name);
 export const getVoiceMap = () => new Map(getAllVoices().map(v => [v.name, v]));

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -55,6 +55,6 @@ export const sleep = ms => new Promise((res, _rej) => {
 export const escapeRegExp = text => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
 
-export const getAllVoices = () => window.speechSynthesis.getVoices();
+export const getAllVoices = () => speechSynthesis.getVoices();
 export const getAllVoiceNames = () => getAllVoices().map(voice => voice.name);
 export const getVoiceMap = () => new Map(getAllVoices().map(v => [v.name, v]));

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -55,6 +55,6 @@ export const sleep = ms => new Promise((res, _rej) => {
 export const escapeRegExp = text => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
 
-export const getAllVoices = () => speechSynthesis.getVoices();
+export const getAllVoices = () => speechSynthesis?.getVoices() || [];
 export const getAllVoiceNames = () => getAllVoices().map(voice => voice.name);
 export const getVoiceMap = () => new Map(getAllVoices().map(v => [v.name, v]));

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -55,6 +55,6 @@ export const sleep = ms => new Promise((res, _rej) => {
 export const escapeRegExp = text => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
 
-export const getAllVoices = () => speechSynthesis?.getVoices() || [];
+export const getAllVoices = () => window.speechSynthesis?.getVoices() || [];
 export const getAllVoiceNames = () => getAllVoices().map(voice => voice.name);
 export const getVoiceMap = () => new Map(getAllVoices().map(v => [v.name, v]));

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -53,3 +53,8 @@ export const sleep = ms => new Promise((res, _rej) => {
 // https://stackoverflow.com/questions/3115150/how-to-escape-regular-expression-special-characters-using-javascript
 /** @type {(text: String) => String} */
 export const escapeRegExp = text => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+
+
+export const getAllVoices = () => speechSynthesis.getVoices();
+export const getAllVoiceNames = () => getAllVoices().map(voice => voice.name);
+export const getVoiceMap = () => new Map(getAllVoices().map(v => [v.name, v]));


### PR DESCRIPTION
Adds support for switching read-aloud mode voices, as well as the speech speed.

The `store` fckery I did in `ReadAloud.svelte` is purely to deal with Materialify being stupid. Voice names usually have spaces, and Materialify can't handle dropdowns when the `value` of a dropdown entry has whitespaces. So the store just uses a stringified integer for the value, converting it back to the correct voice name when the value changes.

The speech synthesis API also only returns valid values for voices and such after the page is fully loaded, so the readable and derived stores exist for that reason. The actual name of the voice is stored in `speechVoiceNameSetting`, and `speechVoiceName` is set to either the stored value or default value. This also prevents displaying nonexistent voices when a user imports settings from a different browser (ex. Edge has dozens more voices than Firefox, and importing the settings json with an Edge voice will make it switch to the default voice).

I tested this on Edge and Firefox, and it worked in both 