### PR TITLE
player polyfill

### DIFF
--- a/src/js/content_scripts/video_embed.js
+++ b/src/js/content_scripts/video_embed.js
@@ -38,11 +38,13 @@ if (video) {
     window.parent.postMessage(event?.data, '*');
     switch (event?.data?.type) {
     case 'yt-player-function-call':
+    {
       const { fn, args } = event.data;
-      const result = window.player[fn](...args);
+      const result = JSON.parse(JSON.stringify(window.player[fn](...args)));
       window.parent.postMessage({
         type: 'yt-player-function-return', result
-      });
+      }, '*');
+    }
     }
   });
 }

--- a/src/js/content_scripts/video_embed.js
+++ b/src/js/content_scripts/video_embed.js
@@ -35,6 +35,14 @@ if (video) {
     });
   });
   window.addEventListener('message', event => {
-    window.parent.postMessage(event.data, '*');
+    window.parent.postMessage(event?.data, '*');
+    switch (event?.data?.type) {
+      case 'yt-player-function-call':
+        const { fn, args } = event.data;
+        const result = window.player[fn](...args);
+        window.parent.postMessage({
+          type: 'yt-player-function-return', result
+        });
+    }
   });
 }

--- a/src/js/content_scripts/video_embed.js
+++ b/src/js/content_scripts/video_embed.js
@@ -37,12 +37,12 @@ if (video) {
   window.addEventListener('message', event => {
     window.parent.postMessage(event?.data, '*');
     switch (event?.data?.type) {
-      case 'yt-player-function-call':
-        const { fn, args } = event.data;
-        const result = window.player[fn](...args);
-        window.parent.postMessage({
-          type: 'yt-player-function-return', result
-        });
+    case 'yt-player-function-call':
+      const { fn, args } = event.data;
+      const result = window.player[fn](...args);
+      window.parent.postMessage({
+        type: 'yt-player-function-return', result
+      });
     }
   });
 }

--- a/src/js/polyfills/player.js
+++ b/src/js/polyfills/player.js
@@ -1,0 +1,26 @@
+import { readable } from 'svelte/store';
+
+const windowMessage = readable(null, set => {
+  window.addEventListener('message', set);
+  return () => window.removeEventListener('message', set);
+});
+
+export const player = new Proxy({}, { get(_target, fn, _receiver) {
+  const ytPlayerFrame = document.querySelector('iframe[title=video]');
+  return (...args) => new Promise((res, rej) => {
+    if (ytPlayerFrame == null) return rej(new Error('Youtube player frame not found'));
+
+    const unsub = windowMessage.subscribe(e => {
+      if (e?.data?.type !== 'yt-player-function-return') return;
+      unsub();
+      res(e.data.result);
+    });
+
+    ytPlayerFrame.contentWindow.postMessage({
+      type: 'yt-player-function-call', fn, args
+    }, '*');
+  });
+}});
+
+window.ytplayer = player;
+window.player = player;

--- a/src/js/polyfills/player.js
+++ b/src/js/polyfills/player.js
@@ -12,7 +12,10 @@ export const player = new Proxy({}, { get(_target, fn, _receiver) {
 
     const unsub = windowMessage.subscribe(e => {
       if (e?.data?.type !== 'yt-player-function-return') return;
-      unsub();
+      // unsub may not be declared yet
+      setTimeout(() => {
+        unsub();
+      });
       res(e.data.result);
     });
 


### PR DESCRIPTION
The recent development to embed the player in a YouTube 404 page to bypass embed restrictions broke the existing `window.player` api that our livetl api code, future tests in #296, and future features like `keyboard-shortcuts` depend on. This polyfills that with the caveat that all methods are now `async`.
