### PR TITLE
Migrate from getDuration in api live translation

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -104,6 +104,6 @@ const apiLiveStream = videoId => derived(
 /** @type {(videoId: String) => Readable<Message>} */
 export const getLiveTranslations = videoId => derived(apiLiveStream(videoId), $data => {
   if ($data?.videoId !== videoId || !enableAPITLs.get()) return;
-  if ($data?.start / 1000 < window.player.getDuration() - 10) return; // if the timestamp of the translation is more than 10 seconds of the timestamp of the player, ignore it
+  if ($data?.start / 1000 < get(timestamp) - 10) return; // ignore if the translation timestamp is > 10s ahead of the player timestamp
   return transformApiTl($data);
 });

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -101,7 +101,7 @@ export const videoSide = derived(videoSideDepends, ([$videoSide, $autoVert, $win
 
 export const updatePopupActive = writable(false);
 export const videoTitle = writable('LiveTL');
-export const timestamp = writable(0);
+export const timestamp = writable(0); // timestamp in seconds
 export const faviconURL = writable('/48x48.png');
 export const availableMchadUsers = writable([]);
 export const spotlightedTranslator = writable(null);


### PR DESCRIPTION
This uses the timestamp store instead of `window.player.getDuration()` because the player is not always available.

Fixes #338
