### PR TITLE
Prevent white screen before video load

### DIFF
--- a/src/js/content_scripts/video_embed.js
+++ b/src/js/content_scripts/video_embed.js
@@ -7,9 +7,6 @@ const video = params.get('video');
 if (video) {
   document.body.innerHTML = '<div id="player"></div>';
   document.body.style.overflow = 'hidden';
-  window.parent.postMessage({
-    type: 'video-embed-loaded'
-  }, '*');
   YouTubeIframeLoader.load(YT => {
     window.player = new YT.Player('player', {
       height: '100%',
@@ -21,6 +18,11 @@ if (video) {
         fs: 0
       },
       events: {
+        onReady() {
+          window.parent.postMessage({
+            type: 'video-embed-loaded'
+          }, '*');
+        },
         onStateChange() {
           suppress(() => {
             const data = window?.player?.getVideoData();


### PR DESCRIPTION
It did this before, it now waits for the video to actually load before closing the progress spinner

https://user-images.githubusercontent.com/50760816/134117010-a858c9f4-5f02-436b-9427-322ac9e55a80.mp4
