### PR TITLE
Append LiveTL buttons to yt-live-chat-renderer

### DIFF
--- a/src/js/content_scripts/injector.js
+++ b/src/js/content_scripts/injector.js
@@ -69,7 +69,7 @@ const makeButton = (text, callback, color='rgb(0, 153, 255)', icon='') => {
   a.style.flexBasis = 0;
   a.style.position = 'relative';
   a.appendChild(getLiveTLButton(color));
-  const e = document.querySelector('#input-panel');
+  const e = document.querySelector('yt-live-chat-renderer');
   let elem = e.querySelector('.livetlButtonWrapper');
   if (!elem) {
     elem = document.createElement('div');


### PR DESCRIPTION
Changes LiveTL buttons to be appended into `yt-live-chat-renderer` rather than `#input-panel`.

Fixes #335, and also the bug where LiveTL buttons disappear after toggling Top Chat / Live Chat.
