### PR TITLE
Don't show mchad translations of different language

### DIFF
--- a/src/__tests__/js/mchad.js
+++ b/src/__tests__/js/mchad.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-undef */
+import { getRoomTagLanguageCode } from '../../js/mchad.js';
+
+it.each([
+  [ 'en', 'en' ],
+  [ 'eng', 'en' ],
+  [ 'Français', 'fr' ],
+  [ '日本語', 'jp' ],
+  [ 'es -> en', 'en' ],
+  [ '', null ],
+  [ 'lalala lalala', null ]
+])('getRoomTagLanguageCode("%s") == %s', (tag, expected) => {
+  expect(getRoomTagLanguageCode(tag)).toEqual(expected);
+});

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -63,7 +63,8 @@ const authorName = (() => {
   const lookup = new Map();
   const addTranslator = translator => lookup.set(translator.userID, translator.displayName);
   const addTranslators = translators => translators.forEach(addTranslator);
-  fetch(url('/translators/registered')).then(toJson).then(addTranslators);
+  // check for window.fetch to make jest stfu
+  if (window.fetch) fetch(url('/translators/registered')).then(toJson).then(addTranslators);
   return lookup.get.bind(lookup);
 })();
 

--- a/src/js/mchad.js
+++ b/src/js/mchad.js
@@ -1,4 +1,4 @@
-import { MCHAD, AuthorType } from './constants.js';
+import { MCHAD, AuthorType, languages } from './constants.js';
 // eslint-disable-next-line no-unused-vars
 import { Message, MCHADTL, MCHADStreamItem, MCHADLiveRoom, MCHADArchiveRoom, Seconds, UnixTimestamp } from './types.js';
 // eslint-disable-next-line no-unused-vars
@@ -6,6 +6,7 @@ import { derived, get, readable, Readable } from 'svelte/store';
 import { enableMchadTLs, mchadUsers } from './store.js';
 import { combineArr, formatTimestampMillis, sleep, sortBy } from './utils.js';
 import { archiveStreamFromScript, sseToStream } from './api.js';
+import { isLangMatch } from './filter.js';
 
 /** @typedef {(unix: UnixTimestamp) => String} UnixToTimestamp */
 /** @typedef {(unix: UnixTimestamp) => number} UnixToNumber */
@@ -39,6 +40,19 @@ export async function getRooms(videoId) {
 
   return { live, vod };
 }
+
+/** @type {(tag: String) => String[]} */
+const possibleLanguages = tag => languages
+  .map(lang => isLangMatch(tag, lang) ? [lang] : []).flat();
+
+/** @type {(tag: String) => String | null} */
+export const getRoomTagLanguageCode = tag => {
+  const possible = tag
+    .split(/\s+/g)
+    .map(possibleLanguages)
+    .flat();
+  return possible[possible.length - 1]?.code ?? null;
+};
 
 /** @type {(script: MCHADTL[]) => Number} */
 const getFirstTime = script =>

--- a/src/js/mchad.js
+++ b/src/js/mchad.js
@@ -42,8 +42,7 @@ export async function getRooms(videoId) {
 }
 
 /** @type {(tag: String) => String[]} */
-const possibleLanguages = tag => languages
-  .map(lang => isLangMatch(tag, lang) ? [lang] : []).flat();
+const possibleLanguages = tag => languages.filter(lang => isLangMatch(tag, lang));
 
 /** @type {(tag: String) => String | null} */
 export const getRoomTagLanguageCode = tag => {

--- a/src/js/mchad.js
+++ b/src/js/mchad.js
@@ -81,7 +81,7 @@ export async function getArchiveFromRoom(room) {
 
   const firstTime = getFirstTime(script);
   
-  const toMessage = mchadToMessage(room.Room, archiveUnixToTimestamp(firstTime), archiveUnixToNumber(firstTime));
+  const toMessage = mchadToMessage(room.Room, archiveUnixToTimestamp(firstTime), archiveUnixToNumber(firstTime), getRoomTagLanguageCode(room.Tags));
   return script.map(toMessage);
 }
 
@@ -144,12 +144,13 @@ const archiveTimeToInt = archiveTime => archiveTime
 
 let mchadTLCounter = 0;
 
-/** @type {(author: String, unixToString: UnixToTimestamp, unixToNumber: UnixToNumber) => (data: MCHADTL) => Message} */
-const mchadToMessage = (author, unixToTimestamp, unixToNumber) => data => ({
+/** @type {(author: String, unixToString: UnixToTimestamp, unixToNumber: UnixToNumber, langCode: String | null) => (data: MCHADTL) => Message} */
+const mchadToMessage = (author, unixToTimestamp, unixToNumber, langCode) => data => ({
   text: data.Stext,
   messageArray: [{ type: 'text', text: data.Stext }],
   author,
   authorId: author,
+  langCode,
   messageId: ++mchadTLCounter,
   timestamp: unixToTimestamp(data.Stime),
   types: AuthorType.mchad,
@@ -160,7 +161,8 @@ const mchadToMessage = (author, unixToTimestamp, unixToNumber) => data => ({
 export const getRoomTranslations = room => derived(streamRoom(room.Nick), (data, set) => {
   if (!enableMchadTLs.get()) return;
   const flag = data?.flag;
-  const toMessage = mchadToMessage(room.Nick, liveUnixToTimestamp, (unix) => unix);
+  const langCode = getRoomTagLanguageCode(room.Tags);
+  const toMessage = mchadToMessage(room.Nick, liveUnixToTimestamp, (u) => u, langCode);
   if (flag === 'insert' || flag === 'update') {
     set(toMessage(data.content));
   }

--- a/src/js/sources-aggregate.js
+++ b/src/js/sources-aggregate.js
@@ -4,7 +4,7 @@ import { combineStores, sources } from './sources.js';
 import { getSpamAuthors, removeDuplicateMessages } from './sources-util.js';
 import { ytcDeleteBehaviour, sessionHidden, spotlightedTranslator } from './store.js';
 import { channelFilters, mchadUsers, spamMsgAmount, spamMsgInterval } from './store.js';
-import { disableSpecialSpamProtection, enableSpamProtection } from './store.js';
+import { disableSpecialSpamProtection, enableSpamProtection, langCode } from './store.js';
 import { spammersDetected } from './store.js';
 import { defaultCaption, GIGACHAD, YtcDeleteBehaviour } from './constants.js';
 import { checkAndSpeak } from './speech.js';
@@ -97,11 +97,16 @@ export const capturedMessages = readable([], set => {
   };
 });
 
+export const sameLangMessages = derived(
+  [capturedMessages, langCode],
+  ([$msgs, $langCode]) => $msgs.filter(msg => msg.langCode == null || msg.langCode == $langCode)
+);
+
 const spamStores = [spamMsgAmount, spamMsgInterval]
   .map(store => derived(store, Math.round));
 
 const dispDepends = [
-  ...[capturedMessages, allBanned, hidden, spotlightedTranslator],
+  ...[sameLangMessages, allBanned, hidden, spotlightedTranslator],
   ...[...spamStores, whitelistedSpam, enableSpamProtection, disableSpecialSpamProtection]
 ];
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,4 +1,4 @@
-import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour, DisplayMode, paramsEmbedded, AutoLaunchMode } from './constants.js';
+import { Browser, BROWSER, TextDirection, VideoSide, ChatSplit, YtcDeleteBehaviour, DisplayMode, languageNameCode, paramsEmbedded, AutoLaunchMode } from './constants.js';
 import { getAllVoiceNames, getVoiceMap } from './utils.js';
 import { LookupStore, SyncStore } from './storage.js';
 // eslint-disable-next-line no-unused-vars
@@ -135,6 +135,7 @@ export const speechSpeaker = derived(
   [speechVoiceName, voiceNames],
   ([$speechVoiceName, _$voiceNames]) => getVoiceMap().get($speechVoiceName),
 );
+export const langCode = derived(language, $lang => languageNameCode[$lang].code);
 
 export const updatePopupActive = writable(false);
 export const videoTitle = writable('LiveTL');

--- a/src/js/types.js
+++ b/src/js/types.js
@@ -12,8 +12,9 @@
 
 /** @typedef {String} Nickname */
 /** @typedef {String} StreamTitle */
-/** @typedef {{Nick: Nickname, EntryPass: Boolean, Empty: Boolean, StreamLink: String, videoId: String}} MCHADLiveRoom */
-/** @typedef {{Room: Nickname, Link: String, Nick: StreamTitle, Pass: Boolean, Tags: String, StreamLink: String, Star: Number, videoId: String}} MCHADArchiveRoom */
+/** @typedef {{StreamLink: String, videoId: String, Tags: String}} MCHADRoom */
+/** @typedef {MCHADRoom & {Nick: Nickname, EntryPass: Boolean, Empty: Boolean}} MCHADLiveRoom */
+/** @typedef {MCHADRoom & {Room: Nickname, Link: String, Nick: StreamTitle, Pass: Boolean, Star: Number}} MCHADArchiveRoom */
 
 /** @typedef {Message & {unix: String}} ScriptMessage */
 /** @typedef {{id: Number, videoId: String, translatorId: String, languageCode: String, translatedText: String, start: Number, end: Number | null}} APITranslation */

--- a/src/js/types.js
+++ b/src/js/types.js
@@ -2,7 +2,7 @@
 /** @typedef {{type: 'link', url: String, text: String}} LinkMessage */
 /** @typedef {{type: 'emote', src: String}} EmoteMessage */
 /** @typedef {TextMessage | LinkMessage | EmoteMessage} MessageItem */
-/** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, types: Number, authorId: string, messageId: string, timestampMs: number}} Message */
+/** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, types: Number, authorId: string, messageId: string, timestampMs: number, langCode: String | null}} Message */
 
 /** @typedef {Number} Seconds */
 /** @typedef {Number} UnixTimestamp */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,9 +2155,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
+  version "1.0.30001271"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz"
+  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Rationale

Previously, all mchad translations show up regardless of source language. This will be problematic in the new sports festival where there will be -> en translators and -> es translators.


## Tested with

* [kanata stream with -> en translations](https://www.youtube.com/watch?v=ExX_YE6rTGs)
* [holotalk stream with -> es translations](https://www.youtube.com/watch?v=LQcQyLum3Q0)


## Limitations

I have not tested this with live translators yet although if the documentation is correct, it __should__ work. Also, we need to get the translators to all use the correct language tag with their rooms.
