### PR TITLE
Use player workaround always

### DIFF
--- a/src/components/VideoEmbed.svelte
+++ b/src/components/VideoEmbed.svelte
@@ -1,24 +1,26 @@
 <script lang="ts">
-  import type { YTPlayer } from '../ts/youtube-player';
   import { videoSide, faviconURL, videoShortcutAction } from '../js/store.js';
   import { VideoSide } from '../js/constants.js';
-  import { onMount, onDestroy } from 'svelte';
-  import { loadYoutubePlayer } from '../ts/youtube-player';
+  import { onMount } from 'svelte';
   import ProgressCircular from 'smelte/src/components/ProgressCircular';
-  import type { Unsubscriber } from 'svelte/store';
 
   export let videoId: string;
 
-  let tryWorkaround = false;
   let workaroundLoaded = false;
-  let listenerActive = false;
-  let videoShortcutUnsub: Unsubscriber | null = null;
-  let workaroundIframe: HTMLIFrameElement | null = null;
+  let iframe: HTMLIFrameElement | null = null;
 
   const setBLFavicon = () => faviconURL.set('/img/blfavicon.ico');
 
-  const onTryWorkaround = (tryWorkaround: boolean): void => {
-    if (!tryWorkaround || listenerActive) return;
+  const onVideoShortcutAction = (action: string): void => {
+    if (!iframe || action === '') return;
+    iframe.contentWindow?.postMessage({
+      type: 'shortcut-action',
+      action
+    }, '*');
+    videoShortcutAction.set('');
+  };
+
+  onMount(() => {
     window.addEventListener('message', e => {
       if (e.data.type === 'video-embed-loaded') {
         workaroundLoaded = true;
@@ -26,75 +28,26 @@
         setBLFavicon();
       }
     });
-    listenerActive = true;
-
-    videoShortcutUnsub = videoShortcutAction.subscribe((action) => {
-      if (!workaroundIframe || action === '') return;
-      workaroundIframe.contentWindow?.postMessage({
-        type: 'shortcut-action',
-        action
-      }, '*');
-      videoShortcutAction.set('');
-    });
-  };
-
-  const onVideoReady = (player: YTPlayer, runPlayerAction: (action: string) => void): void => {
-    const state = player.getPlayerState();
-    const data = player.getVideoData();
-    if (state === -1 && data.title === '' && data.author === '') {
-      console.log('Video potentially failed to load normally, trying workaround.');
-      tryWorkaround = true;
-      return;
-    }
-
-    videoShortcutUnsub = videoShortcutAction.subscribe((action) => {
-      if (action === '') return;
-      runPlayerAction(action);
-      videoShortcutAction.set('');
-    });
-  };
-
-  const onVideoStateChange = (player: YTPlayer): void => {
-    if (player.getVideoData().author.includes('Marine Ch.')) {
-      setBLFavicon();
-    }
-  };
-
-  onMount(() => {
-    loadYoutubePlayer(
-      videoId,
-      onVideoReady,
-      onVideoStateChange
-    );
   });
-  onDestroy(() => {
-    if (videoShortcutUnsub) videoShortcutUnsub();
-  });
-  $: onTryWorkaround(tryWorkaround);
+  $: onVideoShortcutAction($videoShortcutAction);
 </script>
 
 <div
   class:left-video={$videoSide === VideoSide.LEFT}
   class:top-video={$videoSide === VideoSide.TOP}
 >
-  {#if !tryWorkaround}
-    <div class="w-full h-full">
-      <div id="player" />
+  {#if !workaroundLoaded}
+    <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2">
+      <ProgressCircular />
     </div>
-  {:else}
-    {#if !workaroundLoaded}
-      <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2">
-        <ProgressCircular />
-      </div>
-    {/if}
-    <iframe
-      title="video"
-      src="https://www.youtube.com/error?video={videoId}"
-      class="w-full h-full"
-      class:hidden={!workaroundLoaded}
-      bind:this={workaroundIframe}
-    />
   {/if}
+  <iframe
+    title="video"
+    src="https://www.youtube.com/error?video={videoId}"
+    class="w-full h-full"
+    class:hidden={!workaroundLoaded}
+    bind:this={iframe}
+  />
 </div>
 
 <!--<style src="../css/iframe.css"></style>-->

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,6 @@
     "default_icon": "48x48.png"
   },
   "manifest_version": 2,
-  "content_security_policy": "script-src 'self' https://www.youtube.com; object-src 'self'",
   "content_scripts": [
     {
       "matches": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ const transformManifest = (manifestString, version, prod, isChrome = false) => {
     version
   };
   if (isChrome) newManifest.incognito = 'split';
-  if (!prod) newManifest.content_security_policy = 'script-src \'self\' https://www.youtube.com \'unsafe-eval\'; object-src \'self\'';
+  if (!prod) newManifest.content_security_policy = 'script-src \'self\' \'unsafe-eval\'; object-src \'self\'';
   return JSON.stringify(newManifest);
 };
 


### PR DESCRIPTION
Removes the need for the remote `https://www.youtube.com` CSP, while still kinda allowing usage of the YT iframe JS API via postMessage.

Fixes #370.