### PR TITLE
Darker launcher for YTC

### DIFF
--- a/e2e/test_ext.py
+++ b/e2e/test_ext.py
@@ -66,9 +66,9 @@ def test_injection(web):
     # LiveTL Buttons
     @retry
     def _():
-        open_button, popout_button, embed_button = web.find_elements_by_css_selector(".ltl-wrapper > button")
+        open_button, popout_button, embed_button = web.find_elements_by_css_selector("#ltl-wrapper > button")
 
-    open_button, popout_button, embed_button = web.find_elements_by_css_selector(".ltl-wrapper > button")
+    open_button, popout_button, embed_button = web.find_elements_by_css_selector("#ltl-wrapper > button")
     assert open_button.text.strip() == "Open LiveTL"
     assert popout_button.text.strip() == "TL Popout"
     assert embed_button.text.strip() == "Embed TLs"
@@ -221,9 +221,9 @@ def open_embed(web, site=chilled_cow):
 
     @retry
     def _():
-        *_, embed_button, hide_button = web.find_elements_by_css_selector(".ltl-wrapper > button")
+        *_, embed_button, hide_button = web.find_elements_by_css_selector("#ltl-wrapper > button")
 
-    *_, embed_button, hide_button = web.find_elements_by_css_selector(".ltl-wrapper > button")
+    *_, embed_button, hide_button = web.find_elements_by_css_selector("#ltl-wrapper > button")
     embed_button.click()
     time.sleep(5)
 

--- a/e2e/test_ext.py
+++ b/e2e/test_ext.py
@@ -66,9 +66,9 @@ def test_injection(web):
     # LiveTL Buttons
     @retry
     def _():
-        open_button, popout_button, embed_button = web.find_elements_by_css_selector(".livetlButtonWrapper > span")
+        open_button, popout_button, embed_button = web.find_elements_by_css_selector(".ltl-wrapper > button")
 
-    open_button, popout_button, embed_button = web.find_elements_by_css_selector(".livetlButtonWrapper > span")
+    open_button, popout_button, embed_button = web.find_elements_by_css_selector(".ltl-wrapper > button")
     assert open_button.text.strip() == "Open LiveTL"
     assert popout_button.text.strip() == "TL Popout"
     assert embed_button.text.strip() == "Embed TLs"
@@ -221,9 +221,9 @@ def open_embed(web, site=chilled_cow):
 
     @retry
     def _():
-        *_, embed_button = web.find_elements_by_css_selector(".livetlButtonWrapper > span")
+        *_, embed_button, hide_button = web.find_elements_by_css_selector(".ltl-wrapper > button")
 
-    *_, embed_button = web.find_elements_by_css_selector(".livetlButtonWrapper > span")
+    *_, embed_button, hide_button = web.find_elements_by_css_selector(".ltl-wrapper > button")
     embed_button.click()
     time.sleep(5)
 

--- a/e2e/test_ext.py
+++ b/e2e/test_ext.py
@@ -66,9 +66,9 @@ def test_injection(web):
     # LiveTL Buttons
     @retry
     def _():
-        open_button, popout_button, embed_button = web.find_elements_by_css_selector("#ltl-wrapper > button")
+        open_button, popout_button, embed_button, hide_button = web.find_elements_by_css_selector("#ltl-wrapper > button")
 
-    open_button, popout_button, embed_button = web.find_elements_by_css_selector("#ltl-wrapper > button")
+    open_button, popout_button, embed_button, hide_button = web.find_elements_by_css_selector("#ltl-wrapper > button")
     assert open_button.text.strip() == "Open LiveTL"
     assert popout_button.text.strip() == "TL Popout"
     assert embed_button.text.strip() == "Embed TLs"

--- a/src/ts/content_scripts/injector.ts
+++ b/src/ts/content_scripts/injector.ts
@@ -1,8 +1,8 @@
 import { mdiOpenInNew, mdiYoutubeTv, mdiIframeArray } from '@mdi/js';
-import { getFrameInfoAsync, createPopup } from '../../submodules/chat/src/ts/chat-utils.ts';
-import { paramsEmbedDomain, AutoLaunchMode } from '../constants.js';
-import { autoLaunchMode } from '../store.js';
-import { constructParams, openLiveTL } from '../utils.js';
+import { getFrameInfoAsync, createPopup } from '../../submodules/chat/src/ts/chat-utils';
+import { paramsEmbedDomain, AutoLaunchMode } from '../../js/constants.js';
+import { autoLaunchMode } from '../../js/store.js';
+import { constructParams, openLiveTL } from '../../js/utils.js';
 
 for (const eventName of ['visibilitychange', 'webkitvisibilitychange', 'blur']) {
   window.addEventListener(eventName, e => e.stopImmediatePropagation(), true);

--- a/src/ts/content_scripts/injector.ts
+++ b/src/ts/content_scripts/injector.ts
@@ -3,140 +3,42 @@ import { getFrameInfoAsync, createPopup } from '../../submodules/chat/src/ts/cha
 import { paramsEmbedDomain, AutoLaunchMode } from '../../js/constants.js';
 import { autoLaunchMode } from '../../js/store.js';
 import { constructParams, openLiveTL } from '../../js/utils.js';
+import { injectLtlLauncher, ltlButtonParams } from '../utils';
 
 for (const eventName of ['visibilitychange', 'webkitvisibilitychange', 'blur']) {
   window.addEventListener(eventName, e => e.stopImmediatePropagation(), true);
 }
 
-const styleLiveTLButton = (a, color) => {
-  a.style.backgroundColor = `${color || 'rgb(0, 153, 255)'}`;
-  a.style.font = 'inherit';
-  a.style.fontSize = '11px';
-  a.style.fontWeight = 'bold';
-  a.style.width = '100%';
-  a.style.margin = 0;
-  a.style.textAlign = 'center';
-  a.style.display = 'inline-block';
-  // a.style.boxShadow = 'rgb(194 194 194) 0px 0px 4px 1px inset';
-};
-
-const setLiveTLButtonAttributes = (a) => {
-  [
-    'yt-simple-endpoint',
-    'style-scope',
-    'ytd-toggle-button-renderer'
-  ].forEach(c => a.classList.add(c));
-  a.tabindex = '-1';
-};
-
-const getLiveTLButton = (color) => {
-  const a = document.createElement('a');
-  setLiveTLButtonAttributes(a);
-  styleLiveTLButton(a, color);
-  a.innerHTML = `
-  <paper-button id="button" class="style-scope ytd-toggle-button-renderer livetlActivator" role="button" tabindex="0" animated=""
-  elevation="0" aria-disabled="false" style="
-    padding: 5px;
-    display: inline-block;
-    margin: 0;
-    height: auto !important;
-  ">
-    <yt-formatted-string id="text" class="style-scope ytd-toggle-button-renderer" style="display: block;">
-    </yt-formatted-string>
-    <paper-ripple class="style-scope paper-button">
-      <div id="background" class="style-scope paper-ripple" style="opacity: 0.00738;"></div>
-      <div id="waves" class="style-scope paper-ripple"></div>
-    </paper-ripple>
-    <paper-ripple class="style-scope paper-button">
-      <div id="background" class="style-scope paper-ripple" style="opacity: 0.007456;"></div>
-      <div id="waves" class="style-scope paper-ripple"></div>
-    </paper-ripple>
-    <paper-ripple class="style-scope paper-button">
-      <div id="background" class="style-scope paper-ripple" style="opacity: 0.007748;"></div>
-      <div id="waves" class="style-scope paper-ripple"></div>
-    </paper-ripple>
-  </paper-button>
-  `;
-  a.style.height = '100%';
-  a.style.display = 'flex';
-  a.style.justifyContent = 'center';
-  return a;
-};
-
-const makeButton = (text, callback, color = 'rgb(0, 153, 255)', icon = '') => {
-  const a = document.createElement('span');
-  a.style.flexGrow = 1;
-  a.style.flexBasis = 0;
-  a.style.position = 'relative';
-  a.appendChild(getLiveTLButton(color));
-  const e = document.querySelector('yt-live-chat-renderer');
-  let elem = e.querySelector('.livetlButtonWrapper');
+async function loaded(): Promise<void> {
+  const elem = document.querySelector<HTMLElement>('yt-live-chat-app');
   if (!elem) {
-    elem = document.createElement('div');
-    elem.className = 'livetlButtonWrapper';
-    elem.style.display = 'flex';
-    e.appendChild(elem);
+    console.error('Could not find yt-live-chat-app');
+    return;
   }
-  elem.appendChild(a);
-  a.querySelector('a').addEventListener('click', callback);
-  const textbox = a.querySelector('yt-formatted-string');
-  const svg = document.createElement('svg');
-  textbox.textContent = text;
-  textbox.appendChild(svg);
-  textbox.style.color = 'white';
-  svg.outerHTML = `
-    <svg viewBox="0 0 24 24" style="
-      height: 15px;
-      vertical-align: bottom;
-      margin-left: 5px;
-    ">
-      <path d="${icon}" fill="white"></path>
-    </svg>
-  `;
-};
-
-async function loaded() {
-  const elem = document.querySelector('yt-live-chat-app');
   elem.style.minWidth = '0px';
   elem.style.minHeight = '0px';
   elem.style.width = '100%';
   elem.style.height = '100%';
-  elem.style.maxWidth = undefined;
-  elem.style.maxHeight = undefined;
-  const body = document.querySelector('body');
+  elem.style.maxWidth = '';
+  elem.style.maxHeight = '';
+  const body = document.body;
   body.style.width = '100%';
   body.style.height = '100%';
   body.style.position = 'fixed';
-  const css = `
-    .livetlButtonWrapper a.ytd-toggle-button-renderer:hover {
-      background-color: #0099ffb5 !important;
-    }
-    .livetlButtonWrapper a.ytd-toggle-button-renderer {
-      transition: 0.1s;
-    }
-  `;
-  const style = document.createElement('style');
-  style.innerHTML = css;
-  body.appendChild(style);
 
   const frameInfo = await getFrameInfoAsync();
   window.parent.postMessage({ type: 'frameInfo', frameInfo: frameInfo }, '*');
-
-  if (document.querySelector('.livetlButtonWrapper')) {
-    console.debug('LTL buttons already injected. Skipping injection');
-    return;
-  }
 
   if (paramsEmbedDomain === chrome.runtime.id) {
     console.debug('Chat is in extension, not injecting LTL buttons.');
     return;
   }
 
-  const tlPopout = () => {
+  const tlPopout = (): void => {
     const popoutParams = constructParams();
-    popoutParams.set('popout', true);
-    popoutParams.set('tabid', frameInfo.tabId);
-    popoutParams.set('frameid', frameInfo.frameId);
+    popoutParams.set('popout', 'true');
+    popoutParams.set('tabid', frameInfo.tabId.toString());
+    popoutParams.set('frameid', frameInfo.frameId.toString());
     try {
       popoutParams.set(
         'title',
@@ -153,11 +55,11 @@ async function loaded() {
       chrome.runtime.getURL(`popout.html?${popoutParams}`)
     );
   };
-  const embedTLs = () => {
+  const embedTLs = (): void => {
     const embeddedParams = constructParams();
-    embeddedParams.set('embedded', true);
-    embeddedParams.set('tabid', frameInfo.tabId);
-    embeddedParams.set('frameid', frameInfo.frameId);
+    embeddedParams.set('embedded', 'true');
+    embeddedParams.set('tabid', frameInfo.tabId.toString());
+    embeddedParams.set('frameid', frameInfo.frameId.toString());
     document.body.outerHTML = '';
     const iframe = document.createElement('iframe');
     iframe.style.width = '100%';
@@ -191,13 +93,16 @@ async function loaded() {
   });
 
   /** Start buttons injections */
-  makeButton('Open LiveTL', openLiveTL, undefined, mdiYoutubeTv);
-  makeButton('TL Popout', tlPopout, undefined, mdiOpenInNew);
-  makeButton('Embed TLs', embedTLs, undefined, mdiIframeArray);
+  const renderer = document.querySelector<HTMLElement>('yt-live-chat-renderer');
+  injectLtlLauncher(renderer, [
+    ltlButtonParams('Open LiveTL', openLiveTL, mdiYoutubeTv),
+    ltlButtonParams('TL Popout', tlPopout, mdiOpenInNew),
+    ltlButtonParams('Embed TLs', embedTLs, mdiIframeArray)
+  ], { padding: '5px', fontWeight: '700', fontSize: '11px', fontFamily: 'Roboto, Arial, sans-serif', borderWidth: '0' });
 }
 
 window.addEventListener('message', (packet) => {
-  if (packet.origin !== window.origin && !packet.data.type) window.postMessage(packet.data);
+  if (packet.origin !== window.origin && !packet.data.type) window.postMessage(packet.data, '*');
 });
 
 /**

--- a/src/ts/content_scripts/twitch-injector.ts
+++ b/src/ts/content_scripts/twitch-injector.ts
@@ -1,7 +1,7 @@
 import { isVod, parseMessageElement } from '../twitch-parser';
 import { nodeIsElement, injectLtlLauncher, ltlButtonParams } from '../utils';
 import { getFrameInfoAsync, createPopup, isValidFrameInfo } from '../../submodules/chat/src/ts/chat-utils';
-import { mdiOpenInNew, mdiIframeArray, mdiCloseThick } from '@mdi/js';
+import { mdiOpenInNew, mdiIframeArray } from '@mdi/js';
 import { chatSize, twitchEnabled } from '../../js/store';
 import { get } from 'svelte/store';
 

--- a/src/ts/content_scripts/twitch-injector.ts
+++ b/src/ts/content_scripts/twitch-injector.ts
@@ -121,7 +121,7 @@ function injectLtlButtons(frameInfo: Chat.FrameInfo): void {
         ltlWrapper.style.display = 'none';
       }, mdiIframeArray, true);
     }
-  ]);
+  ], { padding: '3px', fontWeight: '600' });
 }
 
 function load(): void {

--- a/src/ts/content_scripts/twitch-injector.ts
+++ b/src/ts/content_scripts/twitch-injector.ts
@@ -1,7 +1,7 @@
 import { isVod, parseMessageElement } from '../twitch-parser';
-import { nodeIsElement } from '../utils';
+import { nodeIsElement, injectLtlLauncher, ltlButtonParams } from '../utils';
 import { getFrameInfoAsync, createPopup, isValidFrameInfo } from '../../submodules/chat/src/ts/chat-utils';
-import { mdiOpenInNew, mdiIframeArray, mdiCloseThick } from '@mdi/js';
+import { mdiOpenInNew, mdiIframeArray } from '@mdi/js';
 import { chatSize } from '../../js/store';
 import { get } from 'svelte/store';
 
@@ -17,163 +17,111 @@ function getCommonParams(frameInfo: Chat.FrameInfo): URLSearchParams {
   return params;
 }
 
-function createButton(text: string, callback: () => void, icon: string, shift = false): HTMLButtonElement {
-  const b = document.createElement('button');
-  b.className = 'ltl-button';
-  b.innerText = text;
-  b.addEventListener('click', callback);
-  const svg = document.createElement('svg');
-  b.appendChild(svg);
-  svg.outerHTML = `
-    <svg viewBox="0 0 24 24" class="ltl-svg ${shift ? 'ltl-shifted-svg' : ''}">
-      <path d="${icon}" fill="white"></path>
-    </svg>
-  `;
-  return b;
-}
-
 function injectLtlButtons(frameInfo: Chat.FrameInfo): void {
-  const chat = document.querySelector(isVod() ? '.video-chat' : '.stream-chat');
+  const chat = document.querySelector<HTMLElement>(isVod() ? '.video-chat' : '.stream-chat');
   if (chat == null) {
     console.error('Could not find chat');
     return;
   }
 
-  const css = `
-    #ltl-wrapper {
-      display: flex;
-      flex-direction: row;
-    }
-    .ltl-button {
-      flex-grow: 1;
-      background-color: #0099ffb5;
-      color: white;
-      padding: 3px;
-      transition: background-color 50ms linear;
-      font-weight: 600;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
-    .ltl-button:hover {
-      background-color: #0099ffa0;
-    }
-    .ltl-svg {
-      height: 15px;
-      vertical-align: middle;
-      margin: 0px 5px;
-    }
-    .ltl-shifted-svg {
-      /* transform: translateY(-1px); */
-    }
-  `;
-  const style = document.createElement('style');
-  style.innerText = css;
-  document.body.appendChild(style);
+  injectLtlLauncher(chat, [
+    () => {
+      const popoutParams = getCommonParams(frameInfo);
+      const popoutUrl = chrome.runtime.getURL(`popout.html?${popoutParams.toString()}`);
+      return ltlButtonParams('TL Popout', () => createPopup(popoutUrl), mdiOpenInNew, true);
+    },
+    (ltlWrapper: HTMLDivElement) => {
+      const embedParams = getCommonParams(frameInfo);
+      embedParams.set('embedded', 'true');
+      const embedUrl = chrome.runtime.getURL(`popout.html?${embedParams.toString()}`);
 
-  const ltlWrapper = document.createElement('div');
-  ltlWrapper.id = 'ltl-wrapper';
-
-  const popoutParams = getCommonParams(frameInfo);
-  const popoutUrl = chrome.runtime.getURL(`popout.html?${popoutParams.toString()}`);
-  const popoutButton = createButton('TL Popout', () => createPopup(popoutUrl), mdiOpenInNew, true);
-
-  const embedParams = getCommonParams(frameInfo);
-  embedParams.set('embedded', 'true');
-  const embedUrl = chrome.runtime.getURL(`popout.html?${embedParams.toString()}`);
-  const createResizableBar = (parent: HTMLDivElement): void => {
-    const resizeBar = document.createElement('div');
-    resizeBar.style.width = '100%';
-    resizeBar.style.height = '10px';
-    resizeBar.style.backgroundColor = '#4d4d4d';
-    resizeBar.style.cursor = 'ns-resize';
-    resizeBar.style.userSelect = 'none';
-    resizeBar.style.color = 'white';
-    resizeBar.style.overflow = 'visible';
-    resizeBar.style.justifyContent = 'center';
-    resizeBar.style.alignItems = 'center';
-    resizeBar.style.width = '100%';
-    resizeBar.style.fontSize = '25px';
-    resizeBar.style.display = 'flex';
-    const dots = document.createElement('span');
-    dots.innerText = '⋯';
-    dots.style.transform = 'translateY(-2.5%)';
-    resizeBar.appendChild(dots);
-    const chatRoom = ltlWrapper.previousElementSibling as HTMLElement;
-    chatRoom.style.overflow = 'hidden auto';
-    const setChatRoomHeight = (height: string): void => {
-      chatRoom.style.maxHeight = height;
-      chatRoom.style.minHeight = height;
-    };
-    setChatRoomHeight(`${get(chatSize)}%`);
-    const header = chat.querySelector(isVod() ? '.video-chat__header' : '.stream-chat-header');
-    if (header == null) {
-      console.error('Could not find header while resizing chat');
-      return;
-    }
-    const refreshHeights = (originalEvent: MouseEvent | undefined = undefined): void => {
-      if (originalEvent && originalEvent.buttons !== 1) return;
-      const clientRect = chatRoom.getBoundingClientRect();
-      const refreshParent = (): void => {
-        const { bottom: resizeBarBottom } = resizeBar.getBoundingClientRect();
-        const { bottom: maxBottom } = chat.getBoundingClientRect();
-        parent.style.height = `${maxBottom - resizeBarBottom}px`;
-      };
-      setChatRoomHeight(`${clientRect.height}px`);
-      refreshParent();
-      parent.style.display = 'none';
-      const updateStyles = (): void => {
-        parent.style.display = 'block';
-        const chatHeight = chat.getBoundingClientRect().height;
-        const chatRoomHeight = chatRoom.getBoundingClientRect().height;
-        const parentHeight = parent.getBoundingClientRect().height;
-        parent.style.height = `${100 * parentHeight / chatHeight}%`;
-        const percent = 100 * chatRoomHeight / chatHeight;
-        setChatRoomHeight(`${percent}%`);
-        chatSize.set(percent);
-      };
-      const maxChatRoomHeight = chat.clientHeight - header.clientHeight - resizeBar.clientHeight;
-      if (originalEvent) {
-        const moveListener = (event: MouseEvent): void => {
-          const chatRoomHeight = Math.min(clientRect.height + (event.clientY - originalEvent.clientY), maxChatRoomHeight);
-          setChatRoomHeight(`${chatRoomHeight}px`);
-          refreshParent();
+      const createResizableBar = (parent: HTMLDivElement): void => {
+        const resizeBar = document.createElement('div');
+        resizeBar.style.width = '100%';
+        resizeBar.style.height = '10px';
+        resizeBar.style.backgroundColor = '#4d4d4d';
+        resizeBar.style.cursor = 'ns-resize';
+        resizeBar.style.userSelect = 'none';
+        resizeBar.style.color = 'white';
+        resizeBar.style.overflow = 'visible';
+        resizeBar.style.justifyContent = 'center';
+        resizeBar.style.alignItems = 'center';
+        resizeBar.style.width = '100%';
+        resizeBar.style.fontSize = '25px';
+        resizeBar.style.display = 'flex';
+        const dots = document.createElement('span');
+        dots.innerText = '⋯';
+        dots.style.transform = 'translateY(-2.5%)';
+        resizeBar.appendChild(dots);
+        const chatRoom = ltlWrapper.previousElementSibling as HTMLElement;
+        chatRoom.style.overflow = 'hidden auto';
+        const setChatRoomHeight = (height: string): void => {
+          chatRoom.style.maxHeight = height;
+          chatRoom.style.minHeight = height;
         };
-        window.addEventListener('mousemove', moveListener);
-        window.addEventListener('mouseup', () => {
-          window.removeEventListener('mousemove', moveListener);
-          updateStyles();
-        });
-      } else {
-        updateStyles();
-      }
-    };
-    resizeBar.addEventListener('mousedown', refreshHeights);
-    window.addEventListener('resize', () => refreshHeights());
-    chat.appendChild(resizeBar);
-  };
+        setChatRoomHeight(`${get(chatSize)}%`);
+        const header = chat.querySelector(isVod() ? '.video-chat__header' : '.stream-chat-header');
+        if (header == null) {
+          console.error('Could not find header while resizing chat');
+          return;
+        }
+        const refreshHeights = (originalEvent: MouseEvent | undefined = undefined): void => {
+          if (originalEvent && originalEvent.buttons !== 1) return;
+          const clientRect = chatRoom.getBoundingClientRect();
+          const refreshParent = (): void => {
+            const { bottom: resizeBarBottom } = resizeBar.getBoundingClientRect();
+            const { bottom: maxBottom } = chat.getBoundingClientRect();
+            parent.style.height = `${maxBottom - resizeBarBottom}px`;
+          };
+          setChatRoomHeight(`${clientRect.height}px`);
+          refreshParent();
+          parent.style.display = 'none';
+          const updateStyles = (): void => {
+            parent.style.display = 'block';
+            const chatHeight = chat.getBoundingClientRect().height;
+            const chatRoomHeight = chatRoom.getBoundingClientRect().height;
+            const parentHeight = parent.getBoundingClientRect().height;
+            parent.style.height = `${100 * parentHeight / chatHeight}%`;
+            const percent = 100 * chatRoomHeight / chatHeight;
+            setChatRoomHeight(`${percent}%`);
+            chatSize.set(percent);
+          };
+          const maxChatRoomHeight = chat.clientHeight - header.clientHeight - resizeBar.clientHeight;
+          if (originalEvent) {
+            const moveListener = (event: MouseEvent): void => {
+              const chatRoomHeight = Math.min(clientRect.height + (event.clientY - originalEvent.clientY), maxChatRoomHeight);
+              setChatRoomHeight(`${chatRoomHeight}px`);
+              refreshParent();
+            };
+            window.addEventListener('mousemove', moveListener);
+            window.addEventListener('mouseup', () => {
+              window.removeEventListener('mousemove', moveListener);
+              updateStyles();
+            });
+          } else {
+            updateStyles();
+          }
+        };
+        resizeBar.addEventListener('mousedown', refreshHeights);
+        window.addEventListener('resize', () => refreshHeights());
+        chat.appendChild(resizeBar);
+      };
 
-  const embedButton = createButton('Embed TLs', () => {
-    const parent = document.createElement('div');
-    const iframe = document.createElement('iframe');
-    iframe.src = embedUrl;
-    iframe.style.width = '100%';
-    iframe.style.height = '100%';
-    parent.style.width = '100%';
-    parent.style.height = '100%';
-    parent.appendChild(iframe);
-    createResizableBar(parent);
-    chat.appendChild(parent);
-    ltlWrapper.style.display = 'none';
-  }, mdiIframeArray, true);
-
-  const hideButton = createButton('', () => (ltlWrapper.style.display = 'none'), mdiCloseThick);
-  hideButton.style.flexGrow = '0';
-
-  ltlWrapper.appendChild(popoutButton);
-  ltlWrapper.appendChild(embedButton);
-  ltlWrapper.appendChild(hideButton);
-  chat.append(ltlWrapper);
+      return ltlButtonParams('Embed TLs', () => {
+        const parent = document.createElement('div');
+        const iframe = document.createElement('iframe');
+        iframe.src = embedUrl;
+        iframe.style.width = '100%';
+        iframe.style.height = '100%';
+        parent.style.width = '100%';
+        parent.style.height = '100%';
+        parent.appendChild(iframe);
+        createResizableBar(parent);
+        chat.appendChild(parent);
+        ltlWrapper.style.display = 'none';
+      }, mdiIframeArray, true);
+    }
+  ]);
 }
 
 function load(): void {

--- a/src/ts/content_scripts/twitch-injector.ts
+++ b/src/ts/content_scripts/twitch-injector.ts
@@ -158,7 +158,7 @@ function load(): void {
       }
       injectLtlButtons(frameInfo);
     })
-    .catch((e) => console.error(e));
+    .catch(console.error);
 }
 
 let first = true;

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,3 +1,5 @@
+import { mdiCloseThick } from '@mdi/js';
+
 export function isValidRegex(regexStr: string): boolean {
   try {
     return Boolean(new RegExp(regexStr));
@@ -8,4 +10,84 @@ export function isValidRegex(regexStr: string): boolean {
 
 export function nodeIsElement(node: Node): node is Element {
   return node.nodeType === Node.ELEMENT_NODE;
+}
+
+export interface LtlButtonParams {
+  text: string;
+  callback: () => void;
+  icon: string;
+  shift: boolean;
+}
+
+export function ltlButtonParams(text: string, callback: () => void, icon: string, shift = false): LtlButtonParams {
+  return { text, callback, icon, shift };
+}
+
+function createLtlButton({ text, callback, icon, shift }: LtlButtonParams): HTMLButtonElement {
+  const b = document.createElement('button');
+  b.className = 'ltl-button';
+  b.innerText = text;
+  b.addEventListener('click', callback);
+  const svg = document.createElement('svg');
+  b.appendChild(svg);
+  svg.outerHTML = `
+    <svg viewBox="0 0 24 24" class="ltl-svg ${shift ? 'ltl-shifted-svg' : ''}">
+      <path d="${icon}" fill="white"></path>
+    </svg>
+  `;
+  return b;
+}
+
+export function injectLtlLauncher(target: HTMLElement, buttons: Array<LtlButtonParams | ((ltlWrapper: HTMLDivElement) => LtlButtonParams)>): void {
+  if (document.getElementById('ltl-wrapper') != null) {
+    console.error('LTL launcher already injected');
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.innerText = `
+    #ltl-wrapper {
+      display: flex;
+      flex-direction: row;
+    }
+    .ltl-button {
+      flex-grow: 1;
+      background-color: #0099ffb5;
+      color: white;
+      padding: 3px;
+      transition: background-color 50ms linear;
+      font-weight: 600;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    .ltl-button:hover {
+      background-color: #0099ffa0;
+    }
+    .ltl-svg {
+      height: 15px;
+      vertical-align: middle;
+      margin: 0px 5px;
+    }
+    .ltl-shifted-svg {
+      /* transform: translateY(-1px); */
+    }
+  `;
+  document.body.appendChild(style);
+
+  const ltlWrapper = document.createElement('div');
+  ltlWrapper.id = 'ltl-wrapper';
+
+  buttons.forEach((button) => {
+    if (typeof button === 'function') {
+      button = button(ltlWrapper);
+    }
+    ltlWrapper.appendChild(createLtlButton(button));
+  });
+
+  const hideButton = createLtlButton(ltlButtonParams('', () => (ltlWrapper.style.display = 'none'), mdiCloseThick));
+  hideButton.style.flexGrow = '0';
+  ltlWrapper.appendChild(hideButton);
+
+  target.appendChild(ltlWrapper);
 }

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -72,6 +72,7 @@ export function injectLtlLauncher(
       display: flex;
       justify-content: center;
       align-items: center;
+      cursor: pointer;
       ${(buttonCss.fontSize != null) ? `font-size: ${buttonCss.fontSize};` : ''}
       ${(buttonCss.fontFamily != null) ? `font-family: ${buttonCss.fontFamily};` : ''}
       ${(buttonCss.borderWidth != null) ? `border-width: ${buttonCss.borderWidth};` : ''}

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -38,7 +38,19 @@ function createLtlButton({ text, callback, icon, shift }: LtlButtonParams): HTML
   return b;
 }
 
-export function injectLtlLauncher(target: HTMLElement, buttons: Array<LtlButtonParams | ((ltlWrapper: HTMLDivElement) => LtlButtonParams)>): void {
+export interface LtlButtonCss {
+  padding: string;
+  fontWeight: string;
+  fontSize?: string;
+  fontFamily?: string;
+  borderWidth?: string;
+}
+
+export function injectLtlLauncher(
+  target: HTMLElement,
+  buttons: Array<LtlButtonParams | ((ltlWrapper: HTMLDivElement) => LtlButtonParams)>,
+  buttonCss: LtlButtonCss
+): void {
   if (document.getElementById('ltl-wrapper') != null) {
     console.error('LTL launcher already injected');
     return;
@@ -54,12 +66,15 @@ export function injectLtlLauncher(target: HTMLElement, buttons: Array<LtlButtonP
       flex-grow: 1;
       background-color: #0099ffb5;
       color: white;
-      padding: 3px;
+      padding: ${buttonCss.padding};
       transition: background-color 50ms linear;
-      font-weight: 600;
+      font-weight: ${buttonCss.fontWeight};
       display: flex;
       justify-content: center;
       align-items: center;
+      ${(buttonCss.fontSize != null) ? `font-size: ${buttonCss.fontSize};` : ''}
+      ${(buttonCss.fontFamily != null) ? `font-family: ${buttonCss.fontFamily};` : ''}
+      ${(buttonCss.borderWidth != null) ? `border-width: ${buttonCss.borderWidth};` : ''}
     }
     .ltl-button:hover {
       background-color: #0099ffa0;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ module.exports = (env, options) => {
       welcome: path.join(__dirname, 'src', 'js', 'pages', 'welcome.js'),
       lite: path.join(__dirname, 'src', 'js', 'pages', 'lite.js'),
       translatormode: path.join(__dirname, 'src', 'js', 'pages', 'translatormode.js'),
-      injector: path.join(__dirname, 'src', 'js', 'content_scripts', 'injector.js'),
+      injector: path.join(__dirname, 'src', 'ts', 'content_scripts', 'injector.ts'),
       'chat-interceptor': path.join(__dirname, 'src', 'submodules', 'chat', 'src', 'ts', 'chat-interceptor.ts'),
       'chat-background': path.join(__dirname, 'src', 'submodules', 'chat', 'src', 'ts', 'chat-background.ts'),
       chat: path.join(__dirname, 'src', 'submodules', 'chat', 'src', 'ts', 'chat-injector.ts'),


### PR DESCRIPTION
Implements the updated launcher from Twitch support to YTC as suggested on #384. I'm using the `twitch` branch as a base since I'm refactoring and reusing the button code from there. I've also took the chance to migrate the YTC injector script to TS.

| Mode | Image |
| --- | --- |
| Light | ![image](https://user-images.githubusercontent.com/20059164/150535075-2b254c7c-fb10-4ddc-98a5-886b70726dac.png) |
| Dark | ![image](https://user-images.githubusercontent.com/20059164/150535117-3b36d6e8-f3e9-4408-b7b7-51a5caa199a8.png) |