### PR TITLE
Fix: don't scroll parent window when scrolling messages

### DIFF
--- a/src/components/MainPane.svelte
+++ b/src/components/MainPane.svelte
@@ -334,7 +334,7 @@
           ? 'arrow_upward'
           : 'arrow_downward'}
         on:click={() => {
-          messageDisplay.scrollToRecent();
+          messageDisplay.scrollToRecent(true);
           updateWrapper();
         }}
         filled

--- a/src/components/MainPane.svelte
+++ b/src/components/MainPane.svelte
@@ -334,7 +334,7 @@
           ? 'arrow_upward'
           : 'arrow_downward'}
         on:click={() => {
-          messageDisplay.scrollToRecent(true);
+          messageDisplay.scrollToRecent();
           updateWrapper();
         }}
         filled

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -10,7 +10,8 @@
     showTimestamp,
     spotlightedTranslator,
     sessionHidden,
-    isSelecting
+    isSelecting,
+    scrollTo
   } from '../js/store.js';
   import { AuthorType, TextDirection } from '../js/constants.js';
   import IntroMessage from './IntroMessage.svelte';
@@ -22,17 +23,17 @@
   export let hideIntro = false;
 
   let bottomMsg: HTMLElement | undefined;
+  let messagesEl: HTMLElement | undefined;
 
-  export function scrollToRecent() {
-    if (!bottomMsg) {
-      console.error('bottomMsg undefined');
+  export function scrollToRecent(smooth = false) {
+    if (!messagesEl) {
+      console.error('messagesEl undefined');
       return;
     }
 
-    bottomMsg.scrollIntoView({
-      behavior: 'auto',
-      block: 'nearest',
-      inline: 'nearest'
+    scrollTo.set({
+      top: direction === TextDirection.BOTTOM ? messagesEl.clientHeight : 0,
+      behavior: smooth ? 'smooth' : 'auto'
     });
   }
 
@@ -67,6 +68,7 @@
 
 <MessageDisplayWrapper>
   <div
+    bind:this={messagesEl}
     class={classes}
     style="font-size: {Math.round($livetlFontSize)}px; word-break: break-word;"
   >

--- a/src/components/MessageDisplay.svelte
+++ b/src/components/MessageDisplay.svelte
@@ -25,15 +25,14 @@
   let bottomMsg: HTMLElement | undefined;
   let messagesEl: HTMLElement | undefined;
 
-  export function scrollToRecent(smooth = false) {
+  export function scrollToRecent() {
     if (!messagesEl) {
       console.error('messagesEl undefined');
       return;
     }
 
     scrollTo.set({
-      top: direction === TextDirection.BOTTOM ? messagesEl.clientHeight : 0,
-      behavior: smooth ? 'smooth' : 'auto'
+      top: direction === TextDirection.BOTTOM ? messagesEl.clientHeight : 0
     });
   }
 

--- a/src/components/Wrapper.svelte
+++ b/src/components/Wrapper.svelte
@@ -1,6 +1,6 @@
 <script>
   import { delayed } from '../js/utils.js';
-  import { isResizing } from '../js/store.js';
+  import { isResizing, scrollTo } from '../js/store.js';
 
   export let zoom = NaN;
 
@@ -22,6 +22,10 @@
   $: style = 'scrollbar-width: thin; scrollbar-color: #888 transparent; ' +
     `width: ${inverse}%; height: ${inverse}%; transform: scale(${factor}); ` +
     ($$props.style ? $$props.style : '');
+
+  $: if (div && $scrollTo) {
+    div.scrollTo($scrollTo);
+  }
 </script>
 
 <div

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -209,3 +209,4 @@ export const anyRecordingShortcut = writable(false);
 export const videoShortcutAction = writable('');
 export const currentlyEditingPreset = writable(-1);
 export const promptToShow = writable(/** @type {String[]} */ ([]));
+export const scrollTo = writable({ top: 0 });

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -209,4 +209,4 @@ export const anyRecordingShortcut = writable(false);
 export const videoShortcutAction = writable('');
 export const currentlyEditingPreset = writable(-1);
 export const promptToShow = writable(/** @type {String[]} */ ([]));
-export const scrollTo = writable({ top: 0 });
+export const scrollTo = writable(/** @type {ScrollToOptions} */ ({ top: 0 }));


### PR DESCRIPTION
Fixes #403 
Closes #407 

This one uses `.scrollTo` instead of intersection observer shenanigans.