### PR TITLE
Remove message duplication & Read aloud duplication

### DIFF
--- a/src/js/sources-aggregate.js
+++ b/src/js/sources-aggregate.js
@@ -157,6 +157,6 @@ export const captionText = readable(defaultCaption, set => {
 // hmr
 if (window.unsubDictation) window.unsubDictation();
 window.unsubDictation = captionText.subscribe($txt => {
-  console.debug(`[LiveTL] Caption text:`, $txt);
-  $txt.text !== defaultCaption.text && checkAndSpeak($txt)
+  console.debug('[LiveTL] Caption text:', $txt);
+  $txt.text !== defaultCaption.text && checkAndSpeak($txt);
 });

--- a/src/js/sources-aggregate.js
+++ b/src/js/sources-aggregate.js
@@ -145,7 +145,10 @@ export const displayedMessages = derived(dispDepends, dispTransform);
 export const captionText = readable(defaultCaption, set => {
   let text = defaultCaption;
   return displayedMessages.subscribe($msgs => {
-    if ($msgs[$msgs.length - 1]?.text != null && $msgs[$msgs.length - 1]?.text !== text) {
+    if ($msgs[$msgs.length - 1]?.text != null &&
+      $msgs[$msgs.length - 1]?.text !== text &&
+      $msgs[$msgs.length - 1]?.messageId !== text?.messageId
+    ) {
       set(text = $msgs[$msgs.length - 1]);
     }
   });
@@ -153,4 +156,7 @@ export const captionText = readable(defaultCaption, set => {
 
 // hmr
 if (window.unsubDictation) window.unsubDictation();
-window.unsubDictation = captionText.subscribe($txt => $txt.text !== defaultCaption.text && checkAndSpeak($txt));
+window.unsubDictation = captionText.subscribe($txt => {
+  console.debug(`[LiveTL] Caption text:`, $txt);
+  $txt.text !== defaultCaption.text && checkAndSpeak($txt)
+});

--- a/src/js/sources-util.js
+++ b/src/js/sources-util.js
@@ -88,10 +88,10 @@ const messageDup = (msg, otherMsg) =>
     msg.types !== otherMsg.types;
 
 /** @type {(msg: Message, otherMsg: Message) => Boolean} */
-const messageEquals = (msg, otherMsg) => msg.messageId === otherMsg.messageId ||
+const messageEquals = (msg, otherMsg) => msg.messageId === otherMsg.messageId || (
   msg.text === otherMsg.text &&
   msg.timestampMs === otherMsg.timestampMs &&
-  msg.authorId === otherMsg.authorId;
+  msg.authorId === otherMsg.authorId);
 
 /** @type {(text: String) => String} */
 const removeWhitespace = text => text.trim().replace(/(\W)\W+/g, '$1');

--- a/src/js/sources-util.js
+++ b/src/js/sources-util.js
@@ -88,7 +88,8 @@ const messageDup = (msg, otherMsg) =>
     msg.types !== otherMsg.types;
 
 /** @type {(msg: Message, otherMsg: Message) => Boolean} */
-const messageEquals = (msg, otherMsg) => msg.text === otherMsg.text &&
+const messageEquals = (msg, otherMsg) => msg.messageId === otherMsg.messageId ||
+  msg.text === otherMsg.text &&
   msg.timestampMs === otherMsg.timestampMs &&
   msg.authorId === otherMsg.authorId;
 

--- a/src/js/speech.js
+++ b/src/js/speech.js
@@ -2,6 +2,7 @@ import { doSpeechSynth, speechVolume, speechSpeed, speechSpeaker } from './store
 import { get } from 'svelte/store';
 
 export function speak(text, langCode, volume = 0) {
+  console.debug(`[LiveTL] Speaking: ${text}`);
   // speechSynthesis.cancel();
   const utterance = new SpeechSynthesisUtterance(text);
   utterance.volume = volume || speechVolume.get();


### PR DESCRIPTION
For some reason, the same message with the same `messageId` is being sent twice. This uses the `messageId` to check for duplicate messages. In the console, HyperChat was complaining about duplicates in the keyed each block which makes me believe we need to do something similar in HyperChat.

Bug was reported by gregsusername#6281 in ltlcord in #tech-support