### PR TITLE
Mark tl as spam with user confirmation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,9 @@ module.exports = {
         ],
         '@typescript-eslint/prefer-nullish-coalescing': 'off',
         // Causes false positives with reactive and auto subscriptions
-        '@typescript-eslint/strict-boolean-expressions': 'off'
+        '@typescript-eslint/strict-boolean-expressions': 'off',
+        'no-unused-expressions': 'off',
+        'no-sequences': 'off',
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LiveTL",
-  "version": "8.2.11",
+  "version": "8.3.0",
   "description": "Get live translations for YouTube and Twitch streams, crowdsourced from multilingual viewers!",
   "scripts": {
     "build": "webpack --mode development",

--- a/src/components/MainPane.svelte
+++ b/src/components/MainPane.svelte
@@ -29,6 +29,7 @@
   import UpdateComponent from './Updates.svelte';
   import MessageDisplay from './MessageDisplay.svelte';
   import FeaturePrompt from './FeaturePrompt.svelte';
+  import SpammerPrompt from './SpammerPrompt.svelte';
   import { displayedMessages } from '../js/sources-aggregate.js';
   import dark from 'smelte/src/dark';
   import Button from './common/IconButton.svelte';
@@ -197,6 +198,7 @@
   renderWidth={$screenshotRenderWidth}
 />
 <UpdateComponent />
+<SpammerPrompt />
 
 <div
   class="flex flex-row gap-2 absolute right-0 p-1 z-20 flex-wrap"

--- a/src/components/SpammerPrompt.svelte
+++ b/src/components/SpammerPrompt.svelte
@@ -74,7 +74,9 @@
     User
     <a
       class="text-primary-400 hover:underline"
-      href="https://www.youtube.com/channel/{spammerInQuestion.authorId}">
+      href="https://www.youtube.com/channel/{spammerInQuestion.authorId}"
+      target="_blank"
+    >
       {spammerInQuestion.author}
     </a>
     has sent at least {$spamMsgAmount} messages in the span
@@ -84,6 +86,7 @@
   <p>You can adjust spam detection options in the settings panel.</p>
 
   <div slot="actions">
+    <Button color="dark" on:click={() => (dialogActive = false)}>Do Nothing</Button>
     <Button color="success" on:click={markAsInnocent}>Whitelist</Button>
     <Button color="error" on:click={markAsSpammer}>Block</Button>
   </div>

--- a/src/components/SpammerPrompt.svelte
+++ b/src/components/SpammerPrompt.svelte
@@ -1,5 +1,14 @@
 <script>
-  import { potentialSpammer, spamMsgAmount, spamMsgInterval, spammersDetected } from '../js/store.js';
+  import {
+    potentialSpammer,
+    spamMsgAmount,
+    spamMsgInterval,
+    spammersDetected,
+    channelFilters,
+    mchadUsers,
+    spammersWhitelisted
+  } from '../js/store.js';
+  import { AuthorType } from '../js/constants.js';
   import { Queue } from '../js/queue.js';
   import Dialog from './common/Dialog.svelte';
   import Button from 'smelte/src/components/Button';
@@ -16,16 +25,27 @@
     }
   };
 
+  const setBool = (bool, spammer) => {
+    if (spammer.types & (AuthorType.mchad | AuthorType.tldex)) {
+      mchadUsers.set(spammer.author, bool);
+    }
+    else {
+      channelFilters.set(spammer.authorId, {
+        name: spammer.author,
+        blacklist: true,
+        whitelist: false,
+      });
+    }
+  };
+
   const markAsSpammer = () => {
-    spammersDetected.set(spammerInQuestion.authorId, {
-      ...spammerInQuestion, spam: true
-    });
+    setBool(true, spammerInQuestion);
     refreshSpammerInQuestion();
   };
 
   const markAsInnocent = () => {
-    spammersDetected.set(spammerInQuestion.authorId, {
-      ...spammerInQuestion, spam: false
+    spammersWhitelisted.set(spammerInQuestion.authorId, {
+      ...spammerInQuestion
     });
     refreshSpammerInQuestion();
   };

--- a/src/components/SpammerPrompt.svelte
+++ b/src/components/SpammerPrompt.svelte
@@ -1,6 +1,8 @@
 <script>
-  import { potentialSpammer, spammersDetected } from '../js/store.js';
+  import { potentialSpammer, spamMsgAmount, spamMsgInterval, spammersDetected } from '../js/store.js';
   import { Queue } from '../js/queue.js';
+  import Dialog from './common/Dialog.svelte';
+  import Button from 'smelte/src/components/Button';
 
   const spammersProcessed = new Set();
   const spammerQueue = new Queue();
@@ -9,6 +11,9 @@
   const refreshSpammerInQuestion = () => {
     if (!spammerQueue.empty()) {
       spammerInQuestion = spammerQueue.pop().data;
+    }
+    else {
+      spammerInQuestion = null;
     }
   };
 
@@ -33,6 +38,34 @@
     if (spammerInQuestion === null) refreshSpammerInQuestion();
   }
 
-  $: window.markAsSpammer = markAsSpammer;
-  $: window.markAsInnocent = markAsInnocent;
+  $: dialogActive = spammerInQuestion !== null;
+  // dialog closed without a definitive answer from user
+  $: if (!dialogActive && spammerInQuestion !== null) {
+    console.log('trying to close');
+    refreshSpammerInQuestion();
+  };
+  $: console.log('RUNNING THIS'), dialogActive = spammerInQuestion !== null;
 </script>
+
+<Dialog
+  title="Block Potential Spammer?"
+  bind:active={dialogActive}
+>
+  <p>
+    User
+    <a
+      class="text-primary-400 hover:underline"
+      href="https://www.youtube.com/channel/{spammerInQuestion.authorId}">
+      {spammerInQuestion.author}
+    </a>
+    has sent at least {$spamMsgAmount} messages in the span
+    of {$spamMsgInterval} seconds.
+  </p>
+
+  <p>You can adjust spam detection options in the settings panel.</p>
+
+  <div slot="actions">
+    <Button color="success" on:click={markAsInnocent}>Whitelist</Button>
+    <Button color="error" on:click={markAsSpammer}>Block</Button>
+  </div>
+</Dialog>

--- a/src/components/SpammerPrompt.svelte
+++ b/src/components/SpammerPrompt.svelte
@@ -1,0 +1,39 @@
+<script>
+  import { potentialSpammer, spammersDetected } from '../js/store.js';
+  import { Queue } from '../js/queue.js';
+
+  const spammersProcessed = new Set();
+  const spammerQueue = new Queue();
+  let spammerInQuestion = $potentialSpammer;
+
+  const refreshSpammerInQuestion = () => {
+    if (!spammerQueue.empty()) {
+      spammerInQuestion = spammerQueue.pop().data;
+    }
+  };
+
+  const markAsSpammer = () => {
+    spammersDetected.set(spammerInQuestion.authorId, { 
+      ...spammerInQuestion, spam: true
+    });
+    refreshSpammerInQuestion();
+  };
+
+  const markAsInnocent = () => {
+    spammersDetected.set(spammerInQuestion.authorId, {
+      ...spammerInQuestion, spam: false
+    });
+    refreshSpammerInQuestion();
+  };
+
+  $: if ($potentialSpammer !== null && !spammersProcessed.has($potentialSpammer.authorId)) {
+    spammerQueue.push($potentialSpammer);
+    spammersProcessed.set($potentialSpammer.authorId);
+    potentialSpammer.set(null);
+    if (spammerInQuestion === null) refreshSpammerInQuestion();
+  }
+
+  $: window.markAsSpammer = markAsSpammer;
+  $: window.markAsInnocent = markAsInnocent;
+  $: console.log('ANSWER WHETHER', spammerInQuestion, 'IS SPAMMER !!!!IMPORTANT');
+</script>

--- a/src/components/SpammerPrompt.svelte
+++ b/src/components/SpammerPrompt.svelte
@@ -13,7 +13,7 @@
   };
 
   const markAsSpammer = () => {
-    spammersDetected.set(spammerInQuestion.authorId, { 
+    spammersDetected.set(spammerInQuestion.authorId, {
       ...spammerInQuestion, spam: true
     });
     refreshSpammerInQuestion();

--- a/src/components/SpammerPrompt.svelte
+++ b/src/components/SpammerPrompt.svelte
@@ -3,7 +3,6 @@
     potentialSpammer,
     spamMsgAmount,
     spamMsgInterval,
-    spammersDetected,
     channelFilters,
     mchadUsers,
     spammersWhitelisted
@@ -28,12 +27,11 @@
   const setBool = (bool, spammer) => {
     if (spammer.types & (AuthorType.mchad | AuthorType.tldex)) {
       mchadUsers.set(spammer.author, bool);
-    }
-    else {
+    } else {
       channelFilters.set(spammer.authorId, {
         name: spammer.author,
         blacklist: true,
-        whitelist: false,
+        whitelist: false
       });
     }
   };

--- a/src/components/SpammerPrompt.svelte
+++ b/src/components/SpammerPrompt.svelte
@@ -11,8 +11,7 @@
   const refreshSpammerInQuestion = () => {
     if (!spammerQueue.empty()) {
       spammerInQuestion = spammerQueue.pop().data;
-    }
-    else {
+    } else {
       spammerInQuestion = null;
     }
   };
@@ -38,13 +37,15 @@
     if (spammerInQuestion === null) refreshSpammerInQuestion();
   }
 
-  $: dialogActive = spammerInQuestion !== null;
-  // dialog closed without a definitive answer from user
-  $: if (!dialogActive && spammerInQuestion !== null) {
-    console.log('trying to close');
-    refreshSpammerInQuestion();
+  let dialogActive = false;
+  const dismiss = () => {
+    if (!dialogActive && spammerInQuestion !== null) {
+      refreshSpammerInQuestion();
+    }
   };
-  $: console.log('RUNNING THIS'), dialogActive = spammerInQuestion !== null;
+  $: dialogActive, dismiss();
+  const refresh = () => (dialogActive = spammerInQuestion !== null);
+  $: spammerInQuestion, refresh();
 </script>
 
 <Dialog

--- a/src/components/SpammerPrompt.svelte
+++ b/src/components/SpammerPrompt.svelte
@@ -28,12 +28,11 @@
 
   $: if ($potentialSpammer !== null && !spammersProcessed.has($potentialSpammer.authorId)) {
     spammerQueue.push($potentialSpammer);
-    spammersProcessed.set($potentialSpammer.authorId);
+    spammersProcessed.add($potentialSpammer.authorId);
     potentialSpammer.set(null);
     if (spammerInQuestion === null) refreshSpammerInQuestion();
   }
 
   $: window.markAsSpammer = markAsSpammer;
   $: window.markAsInnocent = markAsInnocent;
-  $: console.log('ANSWER WHETHER', spammerInQuestion, 'IS SPAMMER !!!!IMPORTANT');
 </script>

--- a/src/components/changelog/Changelog.svelte
+++ b/src/components/changelog/Changelog.svelte
@@ -3,6 +3,21 @@
   import HCChangelogs from '../../submodules/chat/src/components/changelog/Changelog.svelte';
 </script>
 
+<ExpandingCard title="TLdex Improvements" icon="chat">
+  LiveTL will no longer mark chat messages delivered through TLdex
+  with the TLdex badge. The badge will be reserved for translators
+  who use the TLdex translation client.
+</ExpandingCard>
+<ExpandingCard title="Spam Protection Improvements" icon="chat">
+  Previously, LiveTL accidentally marked avid translators such as
+  <a href="https://twitter.com/kamishirotaishi" target="_blank" class="text-blue-400 underline">
+    Kamishiro Taishi
+  </a>
+  as spammers because they sent more than 5 messages within 10 seconds.
+  To prevent accidental blocks, there is now a confirmation dialog when a spammer is detected.
+  We are also internally overhauling the user block/whitelist mechanism -- those Improvements
+  will be included in a future update!
+</ExpandingCard>
 <ExpandingCard title="New HyperChat Features!" icon="chat">
   <HCChangelogs />
 </ExpandingCard>

--- a/src/components/common/Dialog.svelte
+++ b/src/components/common/Dialog.svelte
@@ -15,8 +15,6 @@
     ' max-h-full overflow-y-auto ' +
     (expandWidth ? 'w-full mx-2 ' : ' ') +
     ($$props.class ?? '');
-
-  $: console.log('ACTIVE', active);
 </script>
 
 <Dialog bind:value={active} classes={classes}>

--- a/src/components/common/Dialog.svelte
+++ b/src/components/common/Dialog.svelte
@@ -15,6 +15,8 @@
     ' max-h-full overflow-y-auto ' +
     (expandWidth ? 'w-full mx-2 ' : ' ') +
     ($$props.class ?? '');
+
+  $: console.log('ACTIVE', active);
 </script>
 
 <Dialog bind:value={active} classes={classes}>

--- a/src/components/settings/BlockedUsers.svelte
+++ b/src/components/settings/BlockedUsers.svelte
@@ -8,7 +8,7 @@
   let width = 0;
 </script>
 
-<Card title="Blocked Users" icon="block">
+<Card title="Block/Whitelist Users" icon="block" addHeaderClasses="block-and-whitelist">
   <div class="flex gap-2 flex-wrap" bind:clientWidth={width}>
     <div class="flex-1">
       <MultiDropdown

--- a/src/components/settings/BlockedUsers.svelte
+++ b/src/components/settings/BlockedUsers.svelte
@@ -1,5 +1,10 @@
 <script>
-  import { channelFilters, mchadUsers, enableTldexTLs } from '../../js/store.js';
+  import {
+    channelFilters,
+    mchadUsers,
+    enableTldexTLs,
+    spammersWhitelisted
+  } from '../../js/store.js';
   import MultiDropdown from '../options/MultiDropdown.svelte';
   import Card from '../common/Card.svelte';
 
@@ -8,11 +13,11 @@
   let width = 0;
 </script>
 
-<Card title="Block/Whitelist Users" icon="block" addHeaderClasses="block-and-whitelist">
-  <div class="flex gap-2 flex-wrap" bind:clientWidth={width}>
+<Card title="Blocked/Whitelisted Users" icon="block" addHeaderClasses="block-and-whitelist">
+  <div class="flex gap-2 flex-wrap flex-col" bind:clientWidth={width}>
     <div class="flex-1">
       <MultiDropdown
-        name="Chat users"
+        name="Blocked Chat Users"
         store={channelFilters}
         getDisplayName={(n, v) => v.name}
         getBool={n => channelFilters.get(n).blacklist}
@@ -25,12 +30,21 @@
     {#if $enableTldexTLs}
       <div class="flex-1">
         <MultiDropdown
-          name="TLdex"
+          name="Blocked TLdex Users"
           store={mchadUsers}
           {boundingDiv}
           {width}
         />
       </div>
     {/if}
+    <div class="flex-1">
+      <MultiDropdown
+        name="Whitelisted Users"
+        store={spammersWhitelisted}
+        getDisplayName={(n, v) => v.author}
+        {boundingDiv}
+        {width}
+      />
+    </div>
   </div>
 </Card>

--- a/src/components/settings/SpamProtection.svelte
+++ b/src/components/settings/SpamProtection.svelte
@@ -1,14 +1,12 @@
 <script>
   import {
     enableSpamProtection,
-    spammersDetected,
     spamMsgAmount,
     spamMsgInterval,
     ytcDeleteBehaviour,
     disableSpecialSpamProtection
   } from '../../js/store.js';
   import { ytcDeleteItems } from '../../js/constants.js';
-  import MultiDropdown from '../options/MultiDropdown.svelte';
   import Card from '../common/Card.svelte';
   import Slider from '../common/SliderStore.svelte';
   import Checkbox from '../common/CheckboxStore.svelte';
@@ -16,7 +14,6 @@
 
   export let boundingDiv;
 
-  let width = 0;
   const codeClass = 'px-1 bg-gray-700';
 
   $: amount = `${Math.round($spamMsgAmount)}`;
@@ -38,7 +35,7 @@
       store={disableSpecialSpamProtection}
     />
     <small class="p-2 rounded bg-gray-800">
-      Hide spammers that send <code class={codeClass}>{amount}</code>
+      Block spammers that send <code class={codeClass}>{amount}</code>
       or more messages within <code class={codeClass}>{interval}</code>
       second{intervalPlural}
     </small>
@@ -58,17 +55,16 @@
       step={1}
       showValue={false}
     />
-    <div bind:clientWidth={width}>
-      <MultiDropdown
-        name="Detected spammers"
-        store={spammersDetected}
-        getDisplayName={(_id, v) => v.author}
-        getBool={id => spammersDetected.get(id).spam}
-        setBool={(id, spam) =>
-          spammersDetected.set(id, { ...spammersDetected.get(id), spam })}
-        {boundingDiv}
-        {width}
-      />
-    </div>
+    <small class="p-2 rounded bg-gray-800">
+      User blacklists and whitelists can be adjusted in the
+      <a href="/" class="text-blue-400 underline" on:click={(e) => {
+        e.preventDefault();
+        document.querySelector('.block-and-whitelist').scrollIntoView({
+          behavior: 'smooth',
+          block: 'start'
+        });
+      }}>Block/Whitelist Users</a>
+      section.
+    </small>
   {/if}
 </Card>

--- a/src/components/settings/SpamProtection.svelte
+++ b/src/components/settings/SpamProtection.svelte
@@ -63,7 +63,7 @@
           behavior: 'smooth',
           block: 'start'
         });
-      }}>Block/Whitelist Users</a>
+      }}>Blocked/Whitelisted Users</a>
       section.
     </small>
   {/if}

--- a/src/js/queue.js
+++ b/src/js/queue.js
@@ -12,6 +12,13 @@ export class Queue {
   }
 
   /**
+   * @returns {Boolean}
+   */
+  empty() {
+    return this.top === null || this.top === undefined;
+  }
+
+  /**
    * @returns {T}
    */
   pop() {

--- a/src/js/sources-aggregate.js
+++ b/src/js/sources-aggregate.js
@@ -122,7 +122,7 @@ const spamStores = [spamMsgAmount, spamMsgInterval]
 const dispDepends = [
   ...[sameLangMessages, allBanned, hidden, spotlightedTranslator],
   ...[...spamStores, whitelistedSpam, enableSpamProtection, disableSpecialSpamProtection],
-  ...[spammersDetected],
+  ...[spammersDetected]
 ];
 
 const dispTransform =
@@ -135,7 +135,7 @@ const dispTransform =
       : [];
     spammers.forEach(markSpam);
     const spammerIds = new Set($spamDetected
-      .filter(([id_, data]) => data?.spam)
+      .filter(([_id, data]) => data?.spam)
       .map(([id]) => id));
 
     $items = $items

--- a/src/js/sources-aggregate.js
+++ b/src/js/sources-aggregate.js
@@ -13,7 +13,7 @@ import {
   potentialSpammer,
   disableSpecialSpamProtection,
   langCode,
-  spammersWhitelisted,
+  spammersWhitelisted
 } from './store.js';
 import { defaultCaption, YtcDeleteBehaviour, GIGACHAD } from './constants.js';
 import { checkAndSpeak } from './speech.js';
@@ -119,7 +119,7 @@ const spamStores = [spamMsgAmount, spamMsgInterval]
 
 const dispDepends = [
   ...[sameLangMessages, allBanned, hidden, spotlightedTranslator],
-  ...[...spamStores, whitelistedSpam, enableSpamProtection, disableSpecialSpamProtection],
+  ...[...spamStores, whitelistedSpam, enableSpamProtection, disableSpecialSpamProtection]
 ];
 
 const dispTransform =

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -208,6 +208,10 @@ export class LookupStore {
     this.notify();
   }
 
+  async clear() {
+    return await this.setEntire({});
+  }
+
   /**
    * @param {(v: T) => T} callback
    */

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -226,3 +226,4 @@ export const videoShortcutAction = writable('');
 export const currentlyEditingPreset = writable(-1);
 export const promptToShow = writable(/** @type {String[]} */ ([]));
 export const scrollTo = writable(/** @type {ScrollToOptions} */ ({ top: 0 }));
+export const potentialSpammer = writable(/** @type {typeof sampleSpam | null} */ (null));

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -154,6 +154,20 @@ export const presetStores = [
   }
 })();
 
+// -=- Spammers Migration -=-
+// Taishi got marked as spam, we will unmark all spammers and make spam detection
+// only ban the user upon user confirmation.
+(async () => {
+  const hasDoneSpammerMigration = SS('hasDoneSpammerMigration', false);
+
+  await hasDoneSpammerMigration.loaded;
+
+  if (!hasDoneSpammerMigration.get()) {
+    spammersDetected.clear();
+    hasDoneSpammerMigration.set(true);
+  }
+})();
+
 // Non-persistant stores
 
 /** @typedef {{width: Number, height: Number}} WindowDimension */

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -41,6 +41,7 @@ const sampleFilter = {
   id: ''
 };
 
+const sampleAuthor = { author: '', authorId: '' };
 const sampleSpam = { author: '', authorId: '', spam: false };
 
 export const defaultShortcuts = {
@@ -115,6 +116,7 @@ export const isChatInverted = SS('isChatInverted', false);
 export const twitchEnabled = SS('twitchEnabled', true);
 // tldex is mchad's successor and users want same preference
 export const enableTldexTLs = enableMchadTLs;
+export const spammersWhitelisted = LS('spammersWhiteListed', [sampleAuthor].slice(1));
 
 // All the variables persisted in presets
 export const presetStores = [

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -102,6 +102,8 @@ export const enableSpamProtection = SS('enableSpamProtection', true);
 export const spamMsgAmount = SS('spamMsgAmount', 5);
 export const spamMsgInterval = SS('spamMsgInterval', 10);
 export const spammersDetected = LS('spammersDetected', [sampleSpam].slice(1));
+//           ^^^^^^^^^^^^^^^^   NO LONGER USED
+// see -=- Spammers Migration -=- for more info
 export const speechVoiceNameSetting = SS('speechVoiceNameSetting', '');
 export const speechSpeed = SS('speechSpeed', 1);
 export const autoLaunchMode = SS('autoLaunchMode', AutoLaunchMode.NONE);


### PR DESCRIPTION
Basically does:
```
@r2dev2 just a quick note on what I mean

make it so that when the user first opens this update, the block list is cleared (so probably do it in the changelog component, but keep in mind that can be opened on demand)

add a confirmation dialog when a user is detected for spam, only add to the block list if the user confirms
```
-- @KentoNishi 

- [x] migration to clear spam block list
- [x] logic for user-confirmed spam blocking
- [x] ui for user-confirmed spam blocking