### PR TITLE
Handle YTC TLs from TLdex

### DIFF
--- a/e2e/test_ext.py
+++ b/e2e/test_ext.py
@@ -37,6 +37,7 @@ configure(
 chilled_cow = "https://www.youtube.com/watch?v=5qap5aO4i9A"
 peko_kiara = "https://www.youtube.com/watch?v=c747jYku6Eo"
 mio_phas = "https://www.youtube.com/watch?v=h7F4XJh41uo"
+mio_2 = "https://www.youtube.com/watch?v=4I2iZahIDNg"
 phas = "Phasmophobia"
 
 
@@ -119,10 +120,10 @@ def test_embed_tldex_vod_tls(web):
 
     tl = web.find_element_by_css_selector(".message-display > .message .message-content")
     info = web.find_element_by_css_selector(".message-display > .message .message-info")
-    assert "Mio, this time we're veteran" in tl.text, "Incorrect tl"
-    assert "MonMon TL" in info.text, "Incorrect author of tl"
+    assert "Mio: Ah...." in tl.text, "Incorrect tl"
+    assert "Taishi" in info.text, "Incorrect author of tl"
     assert "TLdex" in info.text, "TLdex badge not found"
-    assert "(00:00:43)" in info.text, "Incorrect tl timestamp"
+    assert "(02:05)" in info.text, "Incorrect tl timestamp"
 
 
 @run_on(all_)
@@ -185,7 +186,7 @@ def test_embed_tl_scroll(web):
 
 
 def open_mio_embed(web):
-    open_embed(web, mio_phas)
+    open_embed(web, mio_2)
     switch_to_youtube_parent_frame(web)
     play_video(web)
     wait_for_ads(web, phas)

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -105,7 +105,7 @@ export const AuthorType = {
 };
 
 export const GIGACHAD =
-  AuthorType.moderator | AuthorType.owner | AuthorType.mchad | AuthorType.api;
+  AuthorType.moderator | AuthorType.owner | AuthorType.mchad | AuthorType.api | AuthorType.tldex;
 
 export const languagesInfo = [
   { code: 'en', name: 'English', lang: 'English', tag: 'en-US' },

--- a/src/js/tldex.js
+++ b/src/js/tldex.js
@@ -31,7 +31,7 @@ export const getArchive = videoLink => readable(null, async set => {
   await languages.loaded;
   const scripts = await Promise.all(languages.get().map((language) => languageNameCode[language]).map(e => e.code).map(async (langcode) => {
     return fetch(`${Holodex}/videos/${videoLink}/chats?lang=${langcode}&verified=0&moderator=0&vtuber=0&tl=1&limit=100000`).then(toJson)
-      .then(e => e.filter(c => !c.is_owner)
+      .then(e => e.filter(c => !c.is_owner && !c.channel_id)
         .map(c => {
           return ({
             author: c.name,
@@ -85,7 +85,7 @@ export const getRoomTranslations = (videoLink, langCode) => derived(streamRoom(v
   if (!enableTldexTLs.get()) return;
   const flag = data?.flag;
 
-  if (flag === 'insert' || flag === 'update') {
+  if ((flag === 'insert' || flag === 'update') && !data?.content?.channel_id) {
     set({
       text: data.content.msg,
       messageArray: [{ type: 'text', text: data.content.msg }],

--- a/src/js/tldex.js
+++ b/src/js/tldex.js
@@ -81,12 +81,9 @@ export const getArchive = videoLink => readable(null, async set => {
 /** @type {(room: String) => Readable<Ty.MCHADStreamItem>} */
 const streamRoom = (videoLink, langcode) => sseToStream(`${MCHAD}/holoproxy?id=YT_${videoLink}&lang=${langcode}`);
 
-/** @type {(time: String) => String} */
-const removeSeconds = time => time.replace(/:\d\d /, ' ');
-
 /** @type {UnixToTimestamp} */
 const liveUnixToTimestamp = unix =>
-  removeSeconds(new Date(unix).toLocaleString('en-us').split(', ')[1]);
+  new Date(unix).toLocaleTimeString('en-us', { hour: '2-digit', minute: '2-digit' });
 
 let mchadTLCounter = 0;
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -29,7 +29,8 @@ export function formatTimestampMillis(millis) {
   const hours = Math.floor(time / 3600);
   const mins = Math.floor(time % 3600 / 60);
   const secs = time % 60;
-  return [hours, mins, secs].map(e => `${e}`.padStart(2, 0)).join(':');
+  if (hours > 0) return [hours, mins, secs].map(e => `${e}`.padStart(2, 0)).join(':');
+  return [mins, secs].map(e => `${e}`.padStart(2, 0)).join(':');
 }
 
 export const toJson = r => r.json();


### PR DESCRIPTION
Overall this will prevent the TLdex badge from showing on YTC TLs that are collected by TLdex, specifically anything that has a `channel_id` value. This also assumes TLdex TLers as trusted users in terms of anti spam. 

On archives, "YTC TLs" from TLdex are treated as normal YTC TLs. This is mainly because the MChad archive migration process had set their internal UUID as `channel_id` in TLdex, which means if we just ignore anything with `channel_id` those will stop showing up in LiveTL (see e2e errors on first 2 commits). Showing old MChad TLs as normal YT TLs is at least better than not showing them at all. It's also just beneficial against YT purging archived chat messages.

On live streams, YTC TLs from TLdex are just ignored. I doubt the TLdex scrapper will catch that much more compared to users' browser chats in real time, and there's not really an easy way to prevent this from happening aside from asking MonMon to pass through all of the user type booleans from TLdex as well:

![image](https://user-images.githubusercontent.com/20059164/174488869-714661ee-c4c0-41ca-87ce-8dd5a239b7bb.png)

@r2dev2 gonna need some help fixing the e2e script. Pretty sure its been complaining ever since we moved from Mchad to TLdex lmao.