### PR TITLE
Prompt user before updating extension

### DIFF
--- a/e2e/test_ext.py
+++ b/e2e/test_ext.py
@@ -34,7 +34,7 @@ configure(
 )
 
 
-chilled_cow = "https://www.youtube.com/watch?v=5qap5aO4i9A"
+chilled_cow = "https://www.youtube.com/watch?v=jfKfPfyJRdk"
 peko_kiara = "https://www.youtube.com/watch?v=c747jYku6Eo"
 mio_phas = "https://www.youtube.com/watch?v=h7F4XJh41uo"
 mio_2 = "https://www.youtube.com/watch?v=4I2iZahIDNg"

--- a/src/components/Updates.svelte
+++ b/src/components/Updates.svelte
@@ -1,18 +1,33 @@
 <script>
   import pkg from '../../package.json';
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount } from 'svelte';
   import { lastVersion, updatePopupActive } from '../js/store.js';
   import Dialog from './common/Dialog.svelte';
   import Button from 'smelte/src/components/Button';
   import Changelog from './changelog/Changelog.svelte';
 
-  let unsubscribe = () => { };
   const version = pkg.version;
+
+  /** @type {string | null} */
+  let updateAvailableVersion = null;
+
+  /** @type {(details: { version: string }) => void} */
+  const handleUpdateAvailable = (details) => {
+    updateAvailableVersion = details.version;
+    $updatePopupActive = true;
+  };
+
+  const updateExtension = () => {
+    updateAvailableVersion = null;
+    $updatePopupActive = false;
+    chrome.runtime.reload();
+    console.log(chrome.runtime.reload);
+  };
 
   onMount(async () => {
     await Promise.all([lastVersion.loaded, updatePopupActive.loaded]);
 
-    unsubscribe = lastVersion.subscribe($lv => {
+    return lastVersion.subscribe($lv => {
       if ($lv !== version) {
         $updatePopupActive = true;
       }
@@ -20,11 +35,22 @@
     });
   });
 
-  onDestroy(() => unsubscribe());
+  onMount(() => {
+    chrome.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);
+    return () => {
+      chrome.runtime.onUpdateAvailable.removeListener(handleUpdateAvailable);
+    };
+  });
 
   function closeUpdate() {
     $updatePopupActive = false;
   }
+
+  // reset when update dialog closed
+  $: if (!$updatePopupActive) {
+    updateAvailableVersion = null;
+  }
+  $: window.handleUpdateAvailable = handleUpdateAvailable;
 </script>
 
 <div class="fixed z-50">
@@ -34,18 +60,29 @@
     bgColor="bg-white dark:bg-dark-700"
   >
     <div slot="title" class="text-center">
-      <h5>New Update!</h5>
-      <h6>Here's what's new in LiveTL version {version}:</h6>
+      {#if updateAvailableVersion === null}
+        <h5>New Update!</h5>
+        <h6>Here's what's new in LiveTL version {version}:</h6>
+      {:else}
+        <h5>New Update Available!</h5>
+        <h6>v{version}</h6>
+      {/if}
     </div>
-    <div class="text-base">
-      <Changelog />
-      <h6 class="text-center">
-        If you like this update, please consider sharing this information with
-        your friends! We'd really appreciate it :)
-      </h6>
-    </div>
-    <div class="update-dialog text-center pt-4">
-      <Button on:click={closeUpdate}>Let's Go!</Button>
-    </div>
+    {#if updateAvailableVersion === null}
+      <div class="text-base">
+        <Changelog />
+        <h6 class="text-center">
+          If you like this update, please consider sharing this information with
+          your friends! We'd really appreciate it :)
+        </h6>
+      </div>
+      <div class="update-dialog text-center pt-4">
+        <Button on:click={closeUpdate}>Let's Go!</Button>
+      </div>
+    {:else}
+      <div class="update-dialog text-center pt-4">
+        <Button on:click={updateExtension}>Update!</Button>
+      </div>
+    {/if}
   </Dialog>
 </div>


### PR DESCRIPTION
Adds an update-available prompt with an explicit extension reload action, alongside the existing post-update changelog.

Updated the existing draft with monorepo `main`, moved the change into `apps/LiveTL/src/components/Updates.svelte`, and retained the current store-unsubscribe cleanup. The obsolete E2E stream change is not part of the port.

Keep draft: the original proposal was tested by manually invoking its callback, not by installing a real update. The event/lifetime and deferral behavior still need a real extension-upgrade test for the supported manifest targets. The prompt currently displays the installed version rather than the pending version, and the manual debug hook remains.

Fixes #419 once the update behavior is completed and validated.

Validation on the ported branch:

- `npm ci`
- `npm run format:check` and `npm run lint:check`
- `node --test .github/scripts/prepare-release.test.mjs` — 10 passed
- `npm run test -- -- --runInBand` — LiveTL: 10 suites, 78 tests passed; the other workspaces currently have placeholder test scripts
- `VERSION=0.0.0 npm run build -- --concurrency=2` — full typecheck, build, verification, and packaging matrix passed

No browser or live YouTube validation was run for this port.
