### PR TITLE
Fix placement of message menu depending on location in screen

### DIFF
--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -111,7 +111,7 @@
     </div>
     <!-- Menu -->
     {#if !screenshot && !$isSelecting}
-      <Menu items={menuItems} visible={focused} class="mr-2">
+      <Menu items={menuItems} visible={focused} class="mr-2" containerQuery=".message-display-wrapper">
         <Icon slot="activator" style="font-size: 1.25em;">more_vert</Icon>
       </Menu>
     {/if}

--- a/src/components/common/Menu.svelte
+++ b/src/components/common/Menu.svelte
@@ -56,23 +56,27 @@
       return;
     }
 
+    const containerEl = document.querySelector(containerQuery) ?? document.body;
     const containerRect = containerEl.getBoundingClientRect();
     const activatorRect = activator.getBoundingClientRect();
     const offsetY = activator.clientHeight + 5;
-    if (activatorRect.top - listDiv.clientHeight > containerRect.top) {
+    if (activatorRect.top - listDiv.clientHeight > Math.max(containerRect.top, 0)) {
+      // put on the top of activator
       offsetYStyle = `bottom: ${offsetY}px;`;
     } else {
+      // put on the bottom of activator
       offsetYStyle = `top: ${offsetY}px;`;
     }
 
-    if (activatorRect.right + listDiv.clientWidth > containerRect.right) {
+    if (activatorRect.right + listDiv.clientWidth > Math.min(containerRect.right, window.innerWidth)) {
+      // put on the left of activator
       offsetX = 'right-0';
     } else {
+      // put on the right of activator
       offsetX = 'left-0';
     }
   };
 
-  $: containerEl = document.querySelector(containerQuery) ?? document.body;
   $: onOpenChange(open);
   $: open = $activeMenuId === id;
   $: classes = (open || visible ? 'visible' : 'invisible') + ' ' +

--- a/src/components/common/Menu.svelte
+++ b/src/components/common/Menu.svelte
@@ -25,13 +25,15 @@
   export let items: MenuItem[];
   export let visible = true;
 
+  // query of the element of which the menu should not overflow
+  // needed for <Menu /> of <Message /> when Message Display is in middle of screen
+  export let containerQuery = 'body';
+
   const id = genId();
 
   let open = false;
   let activator: HTMLElement | undefined;
   let listDiv: HTMLElement | undefined;
-  let windowInnerHeight = 0;
-  let windowInnerWidth = 0;
   let offsetX = '';
   let offsetYStyle = '';
 
@@ -54,21 +56,23 @@
       return;
     }
 
+    const containerRect = containerEl.getBoundingClientRect();
     const activatorRect = activator.getBoundingClientRect();
     const offsetY = activator.clientHeight + 5;
-    if (activatorRect.bottom + listDiv.clientHeight > windowInnerHeight) {
+    if (activatorRect.top - listDiv.clientHeight > containerRect.top) {
       offsetYStyle = `bottom: ${offsetY}px;`;
     } else {
       offsetYStyle = `top: ${offsetY}px;`;
     }
 
-    if (activatorRect.right + listDiv.clientWidth > windowInnerWidth) {
+    if (activatorRect.right + listDiv.clientWidth > containerRect.right) {
       offsetX = 'right-0';
     } else {
       offsetX = 'left-0';
     }
   };
 
+  $: containerEl = document.querySelector(containerQuery) ?? document.body;
   $: onOpenChange(open);
   $: open = $activeMenuId === id;
   $: classes = (open || visible ? 'visible' : 'invisible') + ' ' +
@@ -80,10 +84,6 @@
   'cursor-pointer text-gray-700 dark:text-gray-100 flex items-center z-10';
 </script>
 
-<svelte:window
-  bind:innerHeight={windowInnerHeight}
-  bind:innerWidth={windowInnerWidth}
-/>
 
 <div class={classes}>
   <Menu bind:open>


### PR DESCRIPTION
Taishi reported bug, I forgor to make an issue so I'll just put it here:

In some layout configurations (as shown below), the message menu is hidden by other panels

![message menu hidden](https://user-images.githubusercontent.com/50760816/184471819-77119a72-0f00-4703-9fef-19861f397e85.png)

This pr fixes this by checking the client rectangles against an optionally given container element instead of just the document body.
