### PR TITLE
TLDex Twitch Support For VOD

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -192,3 +192,5 @@ export const defaultCaption = {
 export const modifierKeys = new Set(['Alt', 'Control', 'Meta', 'Shift']);
 
 export const isTwitch = paramsStandalone === 'twitch' || !!(paramsTwitchUrl ?? '');
+export const twitchClientId = 'kimne78kx3ncx6brgo4mv6wki5h1ko';
+export const twitchGQL = 'https://gql.twitch.tv/gql';

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -23,7 +23,7 @@ import * as TLDEX from './tldex.js';
  */
 
 const tldex = derived(
-  combineStores(TLDEX.getArchive(paramsYtVideoId), TLDEX.getLiveTranslations(paramsYtVideoId)).store,
+  combineStores(TLDEX.getArchive(paramsTwitchUrl ?? paramsYtVideoId), TLDEX.getLiveTranslations(paramsYtVideoId)).store,
   ($message) => {
     if (!$message) return;
     const parsed = parseTranslation($message.text);

--- a/src/js/tldex.js
+++ b/src/js/tldex.js
@@ -56,13 +56,12 @@ const getScript = async (url, meta) => await fetch(url)
   .then(sortBy('unix'))
   .catch(() => []);
 
-
 /** @type {(videoLink: String) => Readable<Ty.Message>} */
 export const getArchive = videoLink => readable(null, async set => {
   const startTime = isTwitch
     ? await Twitch.getStartTime(Twitch.getVideoId(videoLink))
     : await getVideoDataWithRetry(videoLink, 3);
-  if (!startTime) return () => { };
+  if (startTime === null || startTime === undefined) return () => { };
 
   await languages.loaded;
   const langCodes = languages

--- a/src/js/tldex.js
+++ b/src/js/tldex.js
@@ -1,4 +1,4 @@
-import { MCHAD, Holodex, AuthorType, languageNameCode } from './constants.js';
+import { MCHAD, Holodex, AuthorType, languageNameCode, isTwitch } from './constants.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as Ty from './types.js';
 import { derived, readable } from 'svelte/store';
@@ -33,33 +33,56 @@ const getTypes = (c) => {
   return types;
 };
 
+/** @type {(url: string, meta: Ty.ScriptMeta) => Promise<Ty.Message[]>} */
+const getScript = async (url, meta) => await fetch(url)
+  .then(toJson)
+  .then(e => e.filter(c => !c.is_owner)
+    .map(c => {
+      return ({
+        author: c.name,
+        authorId: c.channel_id ?? c.name,
+        text: c.message,
+        messageArray: [{ type: 'text', text: c.message }],
+        langCode: meta.langCode,
+        messageId: ++mchadTLCounter,
+        timestamp: formatTimestampMillis(c.timestamp - meta.startTime),
+        types: getTypes(c),
+        timestampMs: c.timestamp - meta.startTime,
+        unix: Math.floor((c.timestamp - meta.startTime) / 1000)
+      });
+    }))
+  .then(s => s.filter(e => e.unix >= 0))
+  .then(sortBy('unix'))
+  .catch(() => []);
+
 /** @type {(videoLink: String) => Readable<Ty.Message>} */
 export const getArchive = videoLink => readable(null, async set => {
-  const startTime = await getVideoDataWithRetry(videoLink, 3);
-  if (!startTime) return () => { };
+  let startTime = isTwitch
+    ? 0
+    : await getVideoDataWithRetry(videoLink, 3);
+  // if (!startTime) return () => { };
 
   await languages.loaded;
-  const scripts = await Promise.all(languages.get().map((language) => languageNameCode[language]).map(e => e.code).map(async (langcode) => {
-    return fetch(`${Holodex}/videos/${videoLink}/chats?lang=${langcode}&verified=0&moderator=0&vtuber=0&tl=1&limit=100000`).then(toJson)
-      .then(e => e.filter(c => !c.is_owner)
-        .map(c => {
-          return ({
-            author: c.name,
-            authorId: c.channel_id ?? c.name,
-            text: c.message,
-            messageArray: [{ type: 'text', text: c.message }],
-            langCode: langcode,
-            messageId: ++mchadTLCounter,
-            timestamp: formatTimestampMillis(c.timestamp - startTime),
-            types: getTypes(c),
-            timestampMs: c.timestamp - startTime,
-            unix: Math.floor((c.timestamp - startTime) / 1000)
-          });
-        }))
-      .then(s => s.filter(e => e.unix >= 0))
-      .then(sortBy('unix'))
-      .catch(() => []);
-  })).then(scripts => scripts.filter(isNotEmpty));
+  const langCodes = languages
+    .get()
+    .map((language) => languageNameCode[language])
+    .map(l => l.code);
+
+  console.log('AM HERE');
+  const scripts = await Promise.all(langCodes.map(async langCode => {
+    const meta = { langCode, startTime };
+    const twitchScript = await getScript(
+      `${Holodex}/videos/custom/chats?tl=1&lang=${langCode}&custom_video_id=${videoLink}`,
+      meta
+    );
+    if (twitchScript.length !== 0) return twitchScript;
+    return await getScript(
+      `${Holodex}/videos/${videoLink}/chats?lang=${langCode}&verified=0&moderator=0&vtuber=0&tl=1&limit=100000`,
+      meta
+    );
+  })).then(scripts => scripts.filter(isNotEmpty)).catch(() => []);
+
+  console.log('got scripts', scripts);
 
   if (scripts.length === 0) return () => { };
 

--- a/src/js/twitch.js
+++ b/src/js/twitch.js
@@ -1,0 +1,55 @@
+import { twitchClientId, twitchGQL } from './constants.js';
+
+/**
+ * Make a graphql fetch request for an auto-persisted query for twitch.
+ *
+ * Twitch uses https://www.apollographql.com/docs/apollo-server/performance/apq/
+ *
+ * It more or less does operationName(variables) on the server and returns response.
+ * Hash has to be of the exact query, so you must get that from the network devtools.
+ * It will stay the same regardless of variables.
+ *
+ * @param {string} operationName operationName from operationName(variables)
+ * @param {Object<string, string>} variables variables from operationName(variables)
+ * @param {string} hash the sha 256 hash of the original query
+ * @return {ReturnType<fetch>}
+ */
+const gqlFetch = (operationName, variables, hash) => fetch(twitchGQL, {
+  method: 'POST',
+  headers: {
+    'Client-Id': twitchClientId
+  },
+  body: JSON.stringify([
+    {
+      operationName,
+      variables,
+      extensions: { persistedQuery: { version: 1, sha256Hash: hash } }
+    }
+  ])
+}).then(r => r.json()).then(json => json[0].data);
+
+/** @type {(videoID: string) => Promise<string | null>} */
+export const getStreamer = (videoID) => gqlFetch(
+  'ChannelVideoCore',
+  { videoID },
+  'cf1ccf6f5b94c94d662efec5223dfb260c9f8bf053239a76125a58118769e8e2'
+).then(data => data.video.owner.login).catch(() => null);
+
+/** @type {(videoID: string, channelLogin?: string) => Promise<number | null>} */
+export const getStartTime = async (videoID, channelLogin) => {
+  if (channelLogin === undefined) {
+    channelLogin = await getStreamer(videoID);
+  }
+  return await gqlFetch(
+    'VideoMetadata',
+    { channelLogin, videoID },
+    '49b5b8f268cdeb259d75b58dcb0c1a748e3b575003448a2333dc5cdafd49adad'
+  ).then(data => new Date(data.video.createdAt).getTime()).catch(() => null);
+};
+
+/** @type {(videoLink: string) => string} */
+export const getVideoId = videoLink => {
+  const parts = videoLink.split('/');
+  return parts[parts.length - 1];
+};
+

--- a/src/js/twitch.js
+++ b/src/js/twitch.js
@@ -52,4 +52,3 @@ export const getVideoId = videoLink => {
   const parts = videoLink.split('/');
   return parts[parts.length - 1];
 };
-

--- a/src/js/types.js
+++ b/src/js/types.js
@@ -19,3 +19,4 @@
 
 /** @typedef {Message & {unix: String}} ScriptMessage */
 /** @typedef {{id: Number, videoId: String, translatorId: String, languageCode: String, translatedText: String, start: Number, end: Number | null}} APITranslation */
+/** @typedef {{ langCode: string, startTime: number }} ScriptMeta */

--- a/src/ts/content_scripts/twitch-injector.ts
+++ b/src/ts/content_scripts/twitch-injector.ts
@@ -151,6 +151,13 @@ function load(): void {
 
   observer.observe(messageContainer, { childList: true });
 
+  const video = document.querySelector('video');
+  setInterval(() => {
+    if (!video) return;
+    // send the unix time in seconds to the extension
+    port.postMessage({ type: 'updatePlayerProgress', playerProgress: video.currentTime, isFromYt: false });
+  }, 500);
+
   getFrameInfoAsync()
     .then((frameInfo) => {
       if (!isValidFrameInfo(frameInfo)) {

--- a/src/ts/sources.ts
+++ b/src/ts/sources.ts
@@ -1,5 +1,6 @@
 import { writable, Writable } from 'svelte/store';
 import { paramsTabId, paramsFrameId } from '../js/constants';
+import { timestamp } from '../js/store';
 
 export function twitchSource(): Writable<Ltl.Message | null> {
   if (paramsTabId == null || paramsFrameId == null) return writable(null);
@@ -17,6 +18,9 @@ export function twitchSource(): Writable<Ltl.Message | null> {
     switch (response.type) {
       case 'ltlMessage':
         messageStore.set(response.message);
+        break;
+      case 'playerProgress':
+        timestamp.set(response.playerProgress);
         break;
     }
   });


### PR DESCRIPTION
Partially addresses #428 (will do tldex live support for twitch in another pr)

This requires a change to the background script of HyperChat. LiveTL/HyperChat#100 needs to be merged and this repository needs to point to the new version before this pr can be merged.

@KentoNishi can you take care of this? I don't know how submodules work.

For testing this pr, you can run in the LiveTL root
```
curl https://patch-diff.githubusercontent.com/raw/LiveTL/HyperChat/pull/100.diff | patch src/submodules/chat/src/scripts/chat-background.ts
```
to apply the changes of LiveTL/HyperChat#100 locally

The stream at https://www.twitch.tv/videos/1542195649 has 11 tldex translations from Taishi.
![Taishi TLs](https://user-images.githubusercontent.com/50760816/187366287-447f7060-5212-4679-939a-871af07bf95d.png)
