### PR TITLE
Fix duplicate messages from tldex and ytc

### DIFF
--- a/src/js/sources-util.js
+++ b/src/js/sources-util.js
@@ -85,7 +85,12 @@ const isDuplicateOf = msg => otherMsg =>
 /** @type {(msg: Message, otherMsg: Message) => Boolean} */
 const messageDup = (msg, otherMsg) =>
   removeWhitespace(msg.text) === removeWhitespace(otherMsg.text) &&
-    msg.types !== otherMsg.types;
+    // after some developments, tldex type means "is verified tldex"
+    // instead of "comes from tldex"
+    // to check if it came from tldex, check typeof messageId
+    // if it came from ytc, it's a string, if it came from tldex, it's a number
+    (msg.types !== otherMsg.types ||
+      typeof msg.messageId !== typeof otherMsg.messageId);
 
 /** @type {(msg: Message, otherMsg: Message) => Boolean} */
 const messageEquals = (msg, otherMsg) => msg.messageId === otherMsg.messageId || (


### PR DESCRIPTION
Previous behaviour error (the duplicated translation)

![image](https://user-images.githubusercontent.com/50760816/206996992-43005cd2-f759-45bc-ac8b-f3ced6849320.png)

Stream to test: https://youtu.be/vQPo4nGV6PY?t=399

This pr fixes the duplicate messages by checking the types of `messageId`