### PR TITLE
feat: Enable Holodex, misc: Options Page

### DIFF
--- a/src/components/LiteOptions.svelte
+++ b/src/components/LiteOptions.svelte
@@ -39,10 +39,7 @@
     </ExpandingCard>
     <ImportExport />
     <Checkbox name="Show timestamps" store={showTimestamp} />
-    <Checkbox
-      name="Show screenshot and download buttons"
-      store={enableExportButtons}
-    />
+    <Checkbox name="Show screenshot and download buttons" store={enableExportButtons} />
   </Card>
   <CommonFilterCards {div} />
   <Card title="Font" icon="format_size">

--- a/src/components/settings/Advanced.svelte
+++ b/src/components/settings/Advanced.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { twitchEnabled } from '../../js/store.js';
+  import { holodexEnabled, twitchEnabled } from '../../js/store.js';
   import About from './About.svelte';
   import Card from '../common/Card.svelte';
   import Checkbox from '../common/CheckboxStore.svelte';
@@ -10,6 +10,7 @@
   Enable LiveTL on:
   <NonstoreCheckbox label="YouTube" checked disabled />
   <Checkbox name="Twitch" store={twitchEnabled} />
+  <Checkbox name="Holodex" store={holodexEnabled} />
 </Card>
 <Card title="About" icon="info">
   <About />

--- a/src/components/settings/UISettings.svelte
+++ b/src/components/settings/UISettings.svelte
@@ -103,10 +103,7 @@
       />
     {/if}
     <Checkbox name="Show timestamps" store={showTimestamp} />
-    <Checkbox
-      name="Show screenshot and download buttons"
-      store={enableExportButtons}
-    />
+    <Checkbox name="Show screenshot and download buttons" store={enableExportButtons} />
     <Checkbox name="Show fullscreen button" store={enableFullscreenButton} />
   </Card>
   {#if $displayMode === DisplayMode.FULLPAGE}

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -116,6 +116,7 @@ export const neverShowSpotlightPrompt = SS('neverShowSpotlightPrompt', false);
 export const showVerifiedMessage = SS('showVerifiedMessage', false);
 export const isChatInverted = SS('isChatInverted', false);
 export const twitchEnabled = SS('twitchEnabled', true);
+export const holodexEnabled = SS('holodexEnabled', true);
 // tldex is mchad's successor and users want same preference
 export const enableTldexTLs = enableMchadTLs;
 export const spammersWhitelisted = LS('spammersWhiteListed', [sampleAuthor].slice(1));

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "name": "LiveTL - Translation Filter for Streams",
   "options_ui": {
     "page": "options.html",
-    "open_in_tab": true
+    "open_in_tab": false
   },
   "permissions": [
     "storage",

--- a/src/ts/content_scripts/injector.ts
+++ b/src/ts/content_scripts/injector.ts
@@ -1,7 +1,7 @@
 import { mdiOpenInNew, mdiYoutubeTv, mdiIframeArray } from '@mdi/js';
 import { getFrameInfoAsync, createPopup, isValidFrameInfo } from '../../submodules/chat/src/ts/chat-utils';
 import { paramsEmbedDomain, AutoLaunchMode } from '../../js/constants.js';
-import { autoLaunchMode } from '../../js/store.js';
+import { autoLaunchMode, holodexEnabled } from '../../js/store.js';
 import { constructParams, openLiveTL } from '../../js/utils.js';
 import { injectLtlLauncher, ltlButtonParams } from '../utils';
 
@@ -10,6 +10,27 @@ for (const eventName of ['visibilitychange', 'webkitvisibilitychange', 'blur']) 
 }
 
 async function loaded(): Promise<void> {
+  try {
+    let hostname = '';
+    if (document.referrer) {
+      const url = new URL(document.referrer);
+      hostname = url.hostname;
+    }
+
+    await holodexEnabled.loaded;
+    if (hostname === 'holodex.net' && !holodexEnabled.get()) { return; }
+  } catch (e) {
+    if (e instanceof Error) {
+      holodexEnabled.subscribe($holodexEnabled => {
+        console.log( document.referrer );
+        console.log({ $holodexEnabled });
+      });
+      console.debug('Could not get hostname', { e });
+    } else {
+      throw e;
+    }
+  }
+
   const elem = document.querySelector<HTMLElement>('yt-live-chat-app');
   if (!elem) {
     console.error('Could not find yt-live-chat-app');

--- a/src/ts/content_scripts/injector.ts
+++ b/src/ts/content_scripts/injector.ts
@@ -18,17 +18,9 @@ async function loaded(): Promise<void> {
     }
 
     await holodexEnabled.loaded;
-    if (hostname === 'holodex.net' && !holodexEnabled.get()) { return; }
+    if (hostname === 'holodex.net' && !holodexEnabled.get()) return;
   } catch (e) {
-    if (e instanceof Error) {
-      holodexEnabled.subscribe($holodexEnabled => {
-        console.log( document.referrer );
-        console.log({ $holodexEnabled });
-      });
-      console.debug('Could not get hostname', { e });
-    } else {
-      throw e;
-    }
+    if (e instanceof Error) console.debug('Could not get hostname', { e });
   }
 
   const elem = document.querySelector<HTMLElement>('yt-live-chat-app');


### PR DESCRIPTION
Created a setting to enable LiveTL on Holodex in Advanced > Additional sites in Options.

Set open_in_tab to false in manifest for Options Page (Firefox) and Embedded Options (Chrome).