### PR TITLE
Fix: emoji not rendered in translation screenshots

### DIFF
--- a/src/components/ScreenshotExport.svelte
+++ b/src/components/ScreenshotExport.svelte
@@ -16,7 +16,9 @@
       await tick();
       const { default: html2canvas } = await import('html2canvas');
       const canvas = await html2canvas(renderElement, {
-        backgroundColor: '#424242'
+        backgroundColor: '#424242',
+        allowTaint: true,
+        useCORS: true
       });
       const base64image = canvas.toDataURL('image/png');
       image = base64image;


### PR DESCRIPTION
Emojis were being rendered as an `img` with a src tag which presumably made the emojis end up not being spotted by html2canvas. This included channel/member-specific emotes too.

Enabling allowTaint and useCORS should allow them to be captured.
src: (https://html2canvas.hertzen.com/configuration)