### PR TITLE
Fix Twitch Parser

### DIFF
--- a/src/ts/twitch-parser.ts
+++ b/src/ts/twitch-parser.ts
@@ -107,6 +107,19 @@ function parseTypes(message: Element): Ltl.AuthorType {
   return types;
 }
 
+function getChildren(node: Element, depth: number): Element[] {
+  const result: Element[] = [];
+  const traverse = (node: Element, depth: number) => {
+    if (depth == 0) return;
+    for (const child of node.children) {
+      result.push(child);
+      traverse(child, depth - 1);
+    }
+  };
+  traverse(node, depth);
+  return result;
+}
+
 export function parseMessageElement(message: Element): Ltl.Message | undefined {
   const author = message.querySelector(displayNameSelector)?.textContent ?? '';
   const timestamp = isVod() ? message.querySelector(vodTimestampSelector)?.textContent ?? '' : currentTime();
@@ -117,7 +130,7 @@ export function parseMessageElement(message: Element): Ltl.Message | undefined {
 
   const messageArray: Ytc.ParsedRun[] = [];
   let text = '';
-  Array.from(messageBody.children).forEach((fragment) => {
+  getChildren(messageBody, 3).forEach((fragment) => {
     // console.debug({ fragment });
     const result = parseMessageFragment(fragment);
     if (result == null) return;

--- a/src/ts/twitch-parser.ts
+++ b/src/ts/twitch-parser.ts
@@ -109,8 +109,8 @@ function parseTypes(message: Element): Ltl.AuthorType {
 
 function getChildren(node: Element, depth: number): Element[] {
   const result: Element[] = [];
-  const traverse = (node: Element, depth: number) => {
-    if (depth == 0) return;
+  const traverse = (node: Element, depth: number): undefined => {
+    if (depth === 0) return;
     for (const child of node.children) {
       result.push(child);
       traverse(child, depth - 1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "checkJs": false,
     "strict": true,
-    "lib": ["DOM"],
+    "lib": ["DOM", "dom.iterable"],
     "target": "esnext",
     "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types", "./src/ts/typings", "./src/submodules/chat/src/ts/typings"]


### PR DESCRIPTION
Twitch updated their message representation in the HTML by nesting the fragments within a div. This caused an issue in our previous parser which only looked at direct children. 

PR changes parser to recursively visit children up to a small depth (3) to search for fragments.

Partially addresses #463 (only the twitch part)