### PR TITLE
[MV2] Fix embeds in "Open in LiveTL" view

### DIFF
--- a/src/js/pages/background.js
+++ b/src/js/pages/background.js
@@ -21,7 +21,6 @@ chrome.webRequest.onHeadersReceived.addListener(
     ]
   }, ['blocking', 'responseHeaders']);
 
-
 // Fixes #478 - embed view does not work without a proper referer
 // youtu.be can be anything just not empty
 // stick to youtu.be to make youtube think this is just a redirect

--- a/src/js/pages/background.js
+++ b/src/js/pages/background.js
@@ -20,3 +20,17 @@ chrome.webRequest.onHeadersReceived.addListener(
       '<all_urls>'
     ]
   }, ['blocking', 'responseHeaders']);
+
+
+// Fixes #478 - embed view does not work without a proper referer
+// youtu.be can be anything just not empty
+// stick to youtu.be to make youtube think this is just a redirect
+browser.webRequest.onBeforeSendHeaders.addListener(
+  details => {
+    const headers = details.requestHeaders;
+    headers.push({ name: 'Referer', value: 'https://youtu.be' });
+    return { requestHeaders: headers };
+  },
+  { urls: ['*://*.youtube.com/embed/*'] },
+  ['blocking', 'requestHeaders']
+);


### PR DESCRIPTION
Add youtu.be as a referer to all youtube.com/embed/* urls in bg script to address mv2 side of #478 

Demo:
<img width="1920" height="905" alt="image" src="https://github.com/user-attachments/assets/6ca8486b-a8a1-4595-921e-daed34e61f04" />