### PR TITLE
[MV3] Fix embeds in "Open in LiveTL" view

### DIFF
--- a/src/add-yt-embed-referer.json
+++ b/src/add-yt-embed-referer.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+          "header": "referer",
+          "operation": "set",
+          "value": "https://youtu.be"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "||youtube.com/embed/",
+      "resourceTypes": ["main_frame", "sub_frame"]
+    }
+  }
+]

--- a/src/js/pages/background.js
+++ b/src/js/pages/background.js
@@ -21,7 +21,6 @@ chrome.webRequest.onHeadersReceived.addListener(
     ]
   }, ['blocking', 'responseHeaders']);
 
-
 // Fixes #478 - embed view does not work without a proper referer
 // youtu.be can be anything just not empty
 // stick to youtu.be to make youtube think this is just a redirect

--- a/src/js/pages/background.js
+++ b/src/js/pages/background.js
@@ -20,3 +20,17 @@ chrome.webRequest.onHeadersReceived.addListener(
       '<all_urls>'
     ]
   }, ['blocking', 'responseHeaders']);
+
+
+// Fixes #478 - embed view does not work without a proper referer
+// youtu.be can be anything just not empty
+// stick to youtu.be to make youtube think this is just a redirect
+browser.webRequest.onBeforeSendHeaders.addListener(
+  details => {
+    const headers = details.requestHeaders;
+    headers.push({ name: 'Referer', value: 'https://youtu.be' });
+    return { requestHeaders: headers };
+  },
+  { urls: ['*://*.youtube.com/embed/*'] },
+  ['blocking', 'requestHeaders']
+);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -79,11 +79,18 @@
     "scripts": ["js/pages/background.js"]
   },
   "{{chrome}}.declarative_net_request": {
-    "rule_resources": [{
-      "id": "allow-iframe",
-      "enabled": true,
-      "path": "allow-iframe.json"
-    }]
+    "rule_resources": [
+      {
+        "id": "allow-iframe",
+        "enabled": true,
+        "path": "allow-iframe.json"
+      },
+      {
+        "id": "add-yt-embed-referer",
+        "enabled": true,
+        "path": "add-yt-embed-referer.json"
+      }
+    ]
   },
   "web_accessible_resources": [
     {

--- a/vite.config.js
+++ b/vite.config.js
@@ -117,6 +117,16 @@ export default defineConfig({
       }]
     }),
 
+    // add-yt-embed-referer.json contains static DeclarativeNetHTTP rules
+    // for allowing embed yt vids, need to manually copy over
+    copy({
+      hook: 'writeBundle',
+      targets: [{
+        src: path.resolve(__dirname, 'src/add-yt-embed-referer.json'),
+        dest: 'build/'
+      }]
+    }),
+
     // include hyperchat's assets
     copy({
       hook: 'writeBundle',


### PR DESCRIPTION
Add youtu.be as a referer to all youtube.com/embed/* urls in bg script to address mv3 side of https://github.com/LiveTL/LiveTL/issues/478

<img width="1920" height="934" alt="fubuki demo" src="https://github.com/user-attachments/assets/748760d4-e0ca-478e-b06a-c50822dee505" />