### PR TITLE
Fix embedded TLs being lost when toggling YouTube fullscreen

### DIFF
--- a/src/ts/content_scripts/injector.ts
+++ b/src/ts/content_scripts/injector.ts
@@ -9,6 +9,15 @@ for (const eventName of ['visibilitychange', 'webkitvisibilitychange', 'blur']) 
   window.addEventListener(eventName, e => e.stopImmediatePropagation(), true);
 }
 
+const EMBED_STORAGE_KEY = 'livetl-chat-embedded';
+
+// `v` identifies a live chat, `continuation` identifies a replay chat. Scoping
+// the persisted embed flag to this keeps it from leaking onto the next
+// stream's chat frame within the same tab.
+const chatId = new URLSearchParams(location.search).get('v') ??
+  new URLSearchParams(location.search).get('continuation');
+const embedStorageKey = chatId != null ? `${EMBED_STORAGE_KEY}:${chatId}` : null;
+
 async function loaded(): Promise<void> {
   try {
     let hostname = '';
@@ -73,6 +82,7 @@ async function loaded(): Promise<void> {
     );
   };
   const embedTLs = (): void => {
+    if (embedStorageKey != null) sessionStorage.setItem(embedStorageKey, 'true');
     const embeddedParams = constructParams();
     embeddedParams.set('embedded', 'true');
     embeddedParams.set('tabid', frameInfo.tabId.toString());
@@ -88,6 +98,15 @@ async function loaded(): Promise<void> {
       iframe.contentWindow?.postMessage(d.data, '*');
     });
   };
+
+  // Toggling fullscreen tears down and recreates this entire frame, which
+  // discards our embed along with the script instance that created it.
+  // sessionStorage survives that recreation (same origin, same tab), so use
+  // it to restore the embed as soon as the fresh instance loads.
+  if (embedStorageKey != null && sessionStorage.getItem(embedStorageKey) === 'true') {
+    embedTLs();
+    return;
+  }
 
   autoLaunchMode.loaded.then(mode => {
     switch (mode) {


### PR DESCRIPTION
Restores the embedded translation view after YouTube recreates its chat iframe during a fullscreen toggle. Persists the embed flag in `sessionStorage`, scoped by the chat URL's video ID or continuation token.

Carried the existing proposal into `apps/LiveTL/src/ts/content_scripts/injector.ts` on monorepo `main`, preserving the original author, commits, review thread, and non-draft state. The original author reported Firefox fullscreen verification before the migration; this adapted port has not been browser-validated.

**Recommendation: hold; treat as draft work before merging.** The outstanding review asks for extension-backed storage and deliberate live-video versus replay identity scoping. The carried implementation still uses `sessionStorage`, so that review is not resolved. Recheck fullscreen restoration and switching streams after addressing it.

Fixes #454 once the outstanding review is addressed.

Validation on the ported branch:

- `npm ci`
- `npm run format:check` and `npm run lint:check`
- `node --test .github/scripts/prepare-release.test.mjs` — 10 passed
- `npm run test -- -- --runInBand` — LiveTL: 10 suites, 78 tests passed; the other workspaces currently have placeholder test scripts
- `VERSION=0.0.0 npm run build -- --concurrency=2` — full typecheck, build, verification, and packaging matrix passed

No browser or live YouTube validation was run for this port.
