### PR TITLE
Remove dead MChad integration

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -126,7 +126,6 @@ function createLangSelectionName(lang) {
 languagesInfo.forEach(i => (languageConversionTable[createLangSelectionName(i)] = i));
 languagesInfo.forEach(lang => (languageNameCode[lang.lang] = lang));
 
-export const MCHAD = 'https://repo.mchatx.org';
 export const Holodex = 'https://holodex.net/api/v2';
 
 const params = new URLSearchParams(window.location.search);

--- a/src/js/sources.js
+++ b/src/js/sources.js
@@ -24,7 +24,7 @@ import { useReconnect } from '../submodules/chat/src/ts/chat-utils.ts';
  */
 
 const tldex = derived(
-  combineStores(TLDEX.getArchive(paramsTwitchUrl ?? paramsYtVideoId), TLDEX.getLiveTranslations(paramsYtVideoId)).store,
+  TLDEX.getArchive(paramsTwitchUrl ?? paramsYtVideoId),
   ($message) => {
     if (!$message) return;
     const parsed = parseTranslation($message.text);

--- a/src/js/tldex.js
+++ b/src/js/tldex.js
@@ -2,15 +2,12 @@ import { Holodex, AuthorType, languageNameCode, holodexKey, isTwitch } from './c
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as Ty from './types.js';
 import * as Twitch from './twitch.js';
-import { derived, readable } from 'svelte/store';
+import { readable } from 'svelte/store';
 import { enableTldexTLs, mchadUsers, languages } from './store.js';
 import { formatTimestampMillis, sleep, sortBy, toJson } from './utils.js';
 import { archiveStreamFromScript } from './api.js';
 
 /** @typedef {import('svelte/store').Readable} Readable */
-/** @typedef {(unix: Ty.UnixTimestamp) => String} UnixToTimestamp */
-/** @typedef {(unix: Ty.UnixTimestamp) => number} UnixToNumber */
-
 /** @type {(arr: Array) => Boolean} */
 const isNotEmpty = arr => arr.length !== 0;
 
@@ -31,7 +28,7 @@ const dexfetch = async (url, default_ = undefined, retry = 40) => {
   }
 };
 
-/** @type {(videoLink: String) => Promise<Ty.MCHADLiveRoom[] | undefined>} */
+/** @type {(videoLink: String) => Promise<number | undefined>} */
 const getVideoDataWithRetry = async (videoLink) => {
   const dt = await dexfetch(`${Holodex}/videos/${videoLink}`);
   if (dt === undefined) return undefined;
@@ -115,45 +112,4 @@ export const getArchive = videoLink => readable(null, async set => {
   return () => unsubscribes.forEach(u => u());
 });
 
-// MCHAD is just down, disable mchad for now
-/** @type {(videoLink: string, langcode: string) => Readable<Ty.MCHADStreamItem>} */
-const streamRoom = (_videoLink, _langcode) => readable();
-// const streamRoom = (videoLink, langcode) => sseToStream(`${MCHAD}/holoproxy?id=YT_${videoLink}&lang=${langcode}`);
-
-/** @type {UnixToTimestamp} */
-const liveUnixToTimestamp = unix =>
-  new Date(unix).toLocaleTimeString('en-us', { hour: '2-digit', minute: '2-digit' });
-
 let mchadTLCounter = 0;
-
-/** @type {(room: Ty.MCHADLiveRoom) => Readable<Ty.Message>} */
-export const getRoomTranslations = (videoLink, langCode) => derived(streamRoom(videoLink, langCode), (data, set) => {
-  if (!enableTldexTLs.get()) return;
-  const flag = data?.flag;
-
-  if ((flag === 'insert' || flag === 'update') && !data?.content?.channel_id) {
-    set({
-      text: data.content.msg,
-      messageArray: [{ type: 'text', text: data.content.msg }],
-      author: data.content.name,
-      authorId: data.content.name,
-      langCode,
-      messageId: ++mchadTLCounter,
-      timestamp: liveUnixToTimestamp(data.content.time),
-      types: AuthorType.tldex,
-      timestampMs: data.content.time
-    });
-  }
-});
-
-/** @type {(link: String) => Readable<Ty.Message>} */
-export const getLiveTranslations = videoLink => readable(null, async set => {
-  await languages.loaded;
-  const unsubscribes = languages.get().map((language) => languageNameCode[language]).map(e => e.code).map(langcode => getRoomTranslations(videoLink, langcode).subscribe(msg => {
-    if (msg && enableTldexTLs.get() && !mchadUsers.get(msg.author)) {
-      set(msg);
-    }
-  }));
-
-  return () => unsubscribes.forEach(u => u());
-});

--- a/src/js/types.js
+++ b/src/js/types.js
@@ -5,17 +5,7 @@
 /** @typedef {{text: String, messageArray: MessageItem[], author: String, timestamp: String, types: Number, authorId: string, messageId: string, timestampMs: number, langCode: String | null}} Message */
 
 /** @typedef {Number} Seconds */
-/** @typedef {Number} UnixTimestamp */
-/** @typedef {String} HexColor */
-/** @typedef {{Stext: String, Stime: UnixTimestamp, CC: HexColor, OC: HexColor}} MCHADTL */
-/** @typedef {MCHADTL & {flag: String}} MCHADStreamItem */
 /** @typedef {(millis: Number) => String} UnixTransformer */
-
-/** @typedef {String} Nickname */
-/** @typedef {String} StreamTitle */
-/** @typedef {{StreamLink: String, videoId: String, Tags: String}} MCHADRoom */
-/** @typedef {MCHADRoom & {Nick: Nickname, EntryPass: Boolean, Empty: Boolean}} MCHADLiveRoom */
-/** @typedef {MCHADRoom & {Room: Nickname, Link: String, Nick: StreamTitle, Pass: Boolean, Star: Number}} MCHADArchiveRoom */
 
 /** @typedef {Message & {unix: String}} ScriptMessage */
 /** @typedef {{id: Number, videoId: String, translatorId: String, languageCode: String, translatedText: String, start: Number, end: Number | null}} APITranslation */


### PR DESCRIPTION
Removes the disabled live MChad source subscription, dead room/stream helpers, endpoint constant, and unused types under `apps/LiveTL`. Keeps Holodex/archive translations, language mapping, and the counter still used by archive messages.

Updated the existing proposal with monorepo `main`, preserving its commits and draft state. The resulting diff is limited to four LiveTL source files.

Recommendation: ready for final review and promotion to merge. This removes an already no-op source; it does not disable the working archive path. Left draft so readiness remains an explicit maintainer decision.

Closes #491.

Validation on the ported branch:

- `npm ci`
- `npm run format:check` and `npm run lint:check`
- Explicit `no-undef` lint check of `apps/LiveTL/src/js/tldex.js`; archive store imports remain present
- `node --test .github/scripts/prepare-release.test.mjs` — 10 passed
- `npm run test -- -- --runInBand` — LiveTL: 10 suites, 78 tests passed; the other workspaces currently have placeholder test scripts
- `VERSION=0.0.0 npm run build -- --concurrency=2` — full typecheck, build, verification, and packaging matrix passed

No browser or live YouTube validation was run for this port.
