### PR TITLE
feat(LiveTL): consume from adjacent HyperChat app instead of submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_TAG }}
-          submodules: recursive
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/submodules/chat"]
-	path = apps/LiveTL/src/submodules/chat
-	url = https://github.com/LiveTL/HyperChat.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,11 @@
 
 - This npm workspace builds LiveTL from `apps/LiveTL` and standalone HyperChat
   from `apps/HyperChat`.
-- LiveTL temporarily continues to consume HyperChat through the submodule at
-  `apps/LiveTL/src/submodules/chat`; the standalone workspace does not replace
-  that runtime boundary yet.
+- LiveTL bundles the shared HyperChat source directly from `apps/HyperChat`.
 - Keep HyperChat implementation details in HyperChat docs. Do not duplicate
   full HyperChat internals here.
 - For chat internals and architecture, start with `apps/HyperChat/README.md` and
-  `apps/HyperChat/AGENTS.md`, then compare the pinned submodule when working on
-  LiveTL's embedded copy.
+  `apps/HyperChat/AGENTS.md`.
 
 ## Branch Discipline (Mandatory)
 
@@ -22,9 +19,8 @@
 - `release` is a legacy rollback branch, not a development or packaging branch.
 - MV2 and MV3 are build targets from the same source, not separate source
   branches. Do not restore the old `develop -> mv3-fr -> release` sync ladder.
-- If a change belongs in HyperChat, land it on HyperChat `main` first, then
-  update the single `apps/LiveTL/src/submodules/chat` gitlink on LiveTL `main`.
-- All LiveTL targets must use the same HyperChat commit.
+- Changes under `apps/HyperChat` affect both standalone HyperChat and LiveTL;
+  verify both applications before merging them to `main`.
 
 ## House Style
 
@@ -39,10 +35,8 @@
 
 ## Code Patterns
 
-- Do not duplicate HyperChat internals in LiveTL when the right fix belongs
-  upstream in the submodule.
-- If a bug spans HyperChat and LiveTL, land the shared chat-side fix in
-  HyperChat first, then bump the submodule in LiveTL.
+- Do not duplicate HyperChat internals in LiveTL when the right fix belongs in
+  the shared `apps/HyperChat` source.
 - Packaged HyperChat translation on Firefox is a split-boundary case: HyperChat
   owns the request/response bridge, while LiveTL owns the bundling entry that
   injects the page-side translator host.
@@ -58,19 +52,12 @@
   YouTube CSP and `X-Frame-Options`. Firefox MV2 therefore remains the published
   Firefox target; Firefox MV3 is validation-only until that requirement changes.
 
-## HyperChat Submodule Mapping
+## HyperChat Workspace Mapping
 
-- LiveTL `main` pins one validated HyperChat `main` commit at
-  `apps/LiveTL/src/submodules/chat` for every build
-  target.
-- After cloning or changing commits, run:
-
-  ```bash
-  git submodule update --init --recursive
-  ```
-
-- If the submodule appears dirty after a branch switch, treat it as a sync issue
-  first, not as a code change.
+- LiveTL imports HyperChat through the `@hyperchat` alias and small build entry
+  modules under `apps/LiveTL/src/hyperchat`.
+- `__LIVETL__` is `true` for LiveTL bundles and `false` for standalone
+  HyperChat bundles. Keep all other shared behavior in `apps/HyperChat`.
 
 ## Branch Switch Hygiene
 
@@ -84,7 +71,7 @@
 - Use a separate worktree for legacy-branch checks or parallel work. Do not
   disturb an existing dirty checkout.
 - If switching leaves untracked build artifacts behind, remove only generated
-  files and normalize submodules before continuing.
+  files before continuing.
 
 ## Build and Test Matrix
 

--- a/AGENT_RELEASE.md
+++ b/AGENT_RELEASE.md
@@ -14,17 +14,14 @@ published.
 `develop` and `release` are retained legacy branches and are not part of normal
 release assembly.
 
-Until LiveTL stops using the submodule, shared HyperChat changes must land in
-upstream HyperChat first, be reflected in `apps/HyperChat`, and then update the
-one `apps/LiveTL/src/submodules/chat` pointer. Do not pin different HyperChat or
-LiveTL commits per browser.
+LiveTL and standalone HyperChat compile the same source from `apps/HyperChat`.
+Do not select different HyperChat or LiveTL source per browser.
 
 ## Pre-release verification
 
 From the exact `main` commit to tag:
 
 ```bash
-git submodule update --init --recursive
 npm ci
 npm run format:check
 npm run test
@@ -70,7 +67,7 @@ the matching GitHub Release:
 
 ```bash
 git switch main
-git pull --ff-only --recurse-submodules
+git pull --ff-only
 git tag vX.Y.Z
 git push origin vX.Y.Z
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ on this [Discord server](https://discord.gg/uJrV3tmthg).**
 
 ### Setting up the environment
 
-1. Clone this repo with submodules (`git clone --recursive https://github.com/LiveTL/LiveTL.git`)
+1. Clone this repo (`git clone https://github.com/LiveTL/LiveTL.git`)
 2. Change directory `cd` to the newly created `LiveTL` repo.
 3. Switch to the maintained branch (`git switch main`)
 4. Install dependencies (`npm ci`)
@@ -99,8 +99,7 @@ help on the [discord server](https://discord.gg/uJrV3tmthg).**
 │   │   ├── content_scripts - has the injector script that injects the LiveTL buttons\
 │   │   └── pages - the exports of the svelte components that represent each LiveTL page\
 │   ├── plugins - plugins for injection to our script\
-│   ├── submodules - submodules\
-│   │   └── chat - the chat optimizer of [Hyperchat](https://www.github.com/LiveTL/HyperChat)\
+│   ├── hyperchat - LiveTL entry points for the shared HyperChat source\
 │   └── __tests__ - tests that match the directory structure of `src`
 
 ## Other

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # LiveTL Monorepo
 
 This repository contains the LiveTL translation extension in `apps/LiveTL` and
-the standalone HyperChat extension in `apps/HyperChat`. LiveTL temporarily
-continues to consume HyperChat through the submodule at
-`apps/LiveTL/src/submodules/chat`.
+the standalone HyperChat extension in `apps/HyperChat`. LiveTL bundles the
+shared HyperChat source directly from the workspace.
 
 [![Build](https://github.com/LiveTL/LiveTL/actions/workflows/build.yml/badge.svg)](https://github.com/LiveTL/LiveTL/actions/workflows/build.yml)
 [![E2E Tests](https://github.com/LiveTL/LiveTL/actions/workflows/tests-e2e.yml/badge.svg)](https://github.com/LiveTL/LiveTL/actions/workflows/tests-e2e.yml)
@@ -37,10 +36,6 @@ for app-specific details.
 ### Setup
 
 > Note: The repo expects a Linux or Unix-like environment. If you are on Windows, use WSL.
-
-> ℹ LiveTL uses submodules. Make sure to clone the repo with the `--recursive` flag!
->
-> ℹ When pulling, you should also use `git pull --recurse`.
 
 ```bash
 npm ci

--- a/apps/HyperChat/AGENTS.md
+++ b/apps/HyperChat/AGENTS.md
@@ -8,7 +8,7 @@ Paths and commands in this file are relative to `apps/HyperChat` unless noted ot
 - `mv3`, `mv3-ltl`, and `mv2` are retired. Do not use them for new work.
 - There is no branch ladder any more. MV2 and MV3 are **build targets on `main`**, not branches — see "Manifest Version Targets" below.
 - HyperChat lives in `apps/HyperChat`; keep repository-wide policy, CI, and release automation at the monorepo root.
-- LiveTL still consumes HyperChat through `apps/LiveTL/src/submodules/chat`. Land shared chat-side fixes in HyperChat `main`, then update that submodule pin on LiveTL `main`.
+- LiveTL bundles this workspace source directly through small entry modules under `apps/LiveTL/src/hyperchat`.
 
 ## House Style
 
@@ -29,11 +29,11 @@ Paths and commands in this file are relative to `apps/HyperChat` unless noted ot
   - `__MV__` in source — a build-time constant, so unused branches are dropped per target.
 - Do not add per-MV source files (`chat-background.mv2.ts` and friends). `main`'s architecture — thin background plus the broker in `src/ts/messaging.ts` — runs under MV2 as-is. Port MV3 patterns down to MV2, never MV2's persistent-background design up.
 - Prefer shared, untagged config. Only tag a key when MV2 and MV3 genuinely differ.
-- Only the two MV3 zips are released. `mv2` is built in CI for breakage coverage and consumed by LiveTL via submodule.
+- Only the two MV3 zips are released. `mv2` is built in CI for breakage coverage; LiveTL builds the shared source separately for its own targets.
 
-## Build-Time Constants (submodule consumers)
+## Build-Time Constants (workspace consumers)
 
-`src/` depends on three bare globals, declared in `src/ts/typings/vite-env.d.ts`
+`src/` depends on four bare globals, declared in `src/ts/typings/vite-env.d.ts`
 and supplied by `vite.config.ts` for our own builds:
 
 | Constant | Emitted literal | Meaning |
@@ -41,6 +41,7 @@ and supplied by `vite.config.ts` for our own builds:
 | `__BROWSER__` | string — `"chrome"` / `"firefox"` | target browser |
 | `__VERSION__` | string — `"3.3.0"` | version written into the manifest |
 | `__MV__` | **number** — `2` / `3` | target manifest version |
+| `__LIVETL__` | boolean | whether HyperChat is bundled into LiveTL |
 
 `__MV__` is compared with strict equality (`__MV__ === 2`), so it must emit a
 **number literal**. Defining it as the string `"2"` makes every check silently
@@ -58,12 +59,13 @@ define: { __BROWSER__: JSON.stringify(browser), __MV__: JSON.stringify(2) }
 new webpack.DefinePlugin({ __BROWSER__: JSON.stringify('firefox'), __MV__: 2 })
 ```
 
-**Anything that compiles this source with its own bundler must define all three**,
+**Anything that compiles this source with its own bundler must define all four**,
 or the bundle ships a reference to an undefined global and throws at runtime.
 LiveTL is the one such consumer: it builds `chat-background.ts`,
 `chat-injector.ts`, `chat-interceptor.ts`, `hyperchat.ts` and `options.ts` as its
 own entry points, so it needs these in **both** its webpack (MV2) and vite (MV3)
-configs. `__MV__` must match that consumer's own manifest version, not ours.
+config. `__MV__` must match that consumer's own manifest version, and
+`__LIVETL__` must be `true` there and `false` in standalone HyperChat.
 
 Used by `WelcomeMessage.svelte`, `Hyperchat.svelte`, `HyperchatButton.svelte`,
 `chat-background.ts`, `chat-injector.ts`. When adding a new constant, update this

--- a/apps/HyperChat/README.md
+++ b/apps/HyperChat/README.md
@@ -73,8 +73,8 @@ VERSION=X.Y.Z npm run build:mv2 -w @livetl/hyperchat     # Firefox MV2
 ```
 
 The built ZIP files can be found in the `build` directory. Only the two MV3 zips
-are published as release assets; the MV2 build is verified in CI and consumed by
-LiveTL through a git submodule.
+are published as release assets; the MV2 build is verified in CI. LiveTL bundles
+this workspace source directly with its own target-specific configuration.
 
 ## Release
 

--- a/apps/HyperChat/src/scripts/chat-injector.ts
+++ b/apps/HyperChat/src/scripts/chat-injector.ts
@@ -23,7 +23,7 @@ const hcWarning = 'An existing HyperChat button has been detected. This ' +
 
 const getScriptURL = (path: string): string => {
   if (isLiveTL) {
-    return chrome.runtime.getURL('submodules/chat/src/scripts/' + path);
+    return chrome.runtime.getURL('hyperchat/scripts/' + path);
   }
   return chrome.runtime.getURL('scripts/' + path);
 };

--- a/apps/HyperChat/src/ts/chat-constants.ts
+++ b/apps/HyperChat/src/ts/chat-constants.ts
@@ -1,5 +1,4 @@
-export const isLiveTL = false;
-// DO NOT EDIT THE ABOVE LINE. It is updated by webpack.
+export const isLiveTL = __LIVETL__;
 
 export const enum Theme {
   YOUTUBE = 'YOUTUBE',

--- a/apps/HyperChat/src/ts/typings/vite-env.d.ts
+++ b/apps/HyperChat/src/ts/typings/vite-env.d.ts
@@ -4,6 +4,8 @@ declare const __VERSION__: string;
 /** Target manifest version. Build-time constant, so `__MV__` branches are
  *  dead-code-eliminated and each bundle only carries its own MV's code. */
 declare const __MV__: 2 | 3;
+/** Whether HyperChat is being bundled as part of LiveTL. */
+declare const __LIVETL__: boolean;
 
 // Vite CSS imports with ?inline suffix
 declare module '*?inline' {

--- a/apps/HyperChat/vite.config.ts
+++ b/apps/HyperChat/vite.config.ts
@@ -27,7 +27,8 @@ export default defineConfig({
   define: {
     __BROWSER__: JSON.stringify(browser),
     __VERSION__: JSON.stringify(version),
-    __MV__: JSON.stringify(mv)
+    __MV__: JSON.stringify(mv),
+    __LIVETL__: JSON.stringify(false)
   },
   plugins: [
     webExtension({

--- a/apps/LiveTL/package.json
+++ b/apps/LiveTL/package.json
@@ -63,7 +63,6 @@
     "postinstall-postinstall": "^2.1.0",
     "request": "2.88.2",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-replace": "^2.2.0",
     "sass": "^1.32.8",
     "sha-1": "^1.0.0",
     "svelte": "3.49.0",

--- a/apps/LiveTL/postcss.config.js
+++ b/apps/LiveTL/postcss.config.js
@@ -32,7 +32,7 @@ module.exports = {
     tailwindcss: tailwindConfig,
     autoprefixer: {},
     '@fullhuman/postcss-purgecss': {
-      content: ['./**/*.svelte'],
+      content: ['./**/*.svelte', '../HyperChat/src/**/*.svelte'],
       extractors: [
         {
           extractor,

--- a/apps/LiveTL/scripts/codex-translation-host-smoke.mjs
+++ b/apps/LiveTL/scripts/codex-translation-host-smoke.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { chromium } from 'playwright-core';
 
-const bundlePath = process.env.BUNDLE_PATH || `${process.cwd()}/build/chrome/submodules/chat/src/scripts/chat-translation-host.js`;
+const bundlePath = process.env.BUNDLE_PATH || `${process.cwd()}/build/chrome/hyperchat/scripts/chat-translation-host.js`;
 
 const resolveBrowserBinary = () => {
   const candidates = [

--- a/apps/LiveTL/scripts/verify-build.mjs
+++ b/apps/LiveTL/scripts/verify-build.mjs
@@ -20,10 +20,13 @@ const assertFile = async (buildDir, target, file) => {
 for (const [target, mv] of Object.entries(targets)) {
   const buildDir = path.resolve('build', target);
   const manifest = JSON.parse(await readFile(path.join(buildDir, 'manifest.json'), 'utf8'));
+  const serializedManifest = JSON.stringify(manifest);
   versions.add(manifest.version);
 
   assert.equal(manifest.manifest_version, mv, `${target}: wrong manifest version`);
-  assert.ok(!JSON.stringify(manifest).includes('{{'), `${target}: unresolved manifest tag`);
+  assert.ok(!serializedManifest.includes('{{'), `${target}: unresolved manifest tag`);
+  assert.ok(!serializedManifest.includes('submodules/chat'), `${target}: legacy HyperChat path`);
+  assert.ok(serializedManifest.includes('hyperchat/scripts/chat-injector.js'), `${target}: missing HyperChat injector`);
 
   if (mv === 2) {
     assert.deepEqual(manifest.background, { page: 'html/background.html', persistent: true }, 'mv2: wrong background');
@@ -65,9 +68,12 @@ for (const [target, mv] of Object.entries(targets)) {
     ...iconFiles(manifest.action?.default_icon),
     ...iconFiles(manifest.browser_action?.default_icon),
     ...(manifest.declarative_net_request?.rule_resources ?? []).map(rule => rule.path),
-    'submodules/chat/src/scripts/chat-interceptor.js',
-    'submodules/chat/src/scripts/chat-metagetter.js',
-    'submodules/chat/src/scripts/chat-translation-host.js',
+    'hyperchat/scripts/chat-interceptor.js',
+    'hyperchat/scripts/chat-metagetter.js',
+    'hyperchat/scripts/chat-translation-host.js',
+    'hyperchat/index.html',
+    'hyperchat/options.html',
+    'hyperchat/logo-48.png',
     'ts/yt-workaround.js'
   ].filter(file => typeof file === 'string');
 
@@ -83,6 +89,14 @@ for (const [target, mv] of Object.entries(targets)) {
       await assertFile(buildDir, target, asset);
     }
   }
+
+  const injector = await readFile(path.join(buildDir, 'hyperchat/scripts/chat-injector.js'), 'utf8');
+  const expectedChatPage = mv === 2 ? 'hyperchat/index.html' : 'youtube.com/embed/hyperchat_embed';
+  assert.ok(injector.includes(expectedChatPage), `${target}: injector has wrong chat page`);
+  assert.ok(injector.includes('hyperchat/scripts/'), `${target}: injector has wrong script base`);
+
+  const tailwind = await readFile(path.join(buildDir, 'tailwind.css'), 'utf8');
+  assert.ok(tailwind.includes('.dark\\:bg-ytbg-dark'), `${target}: missing HyperChat dark theme styles`);
 }
 
 assert.equal(versions.size, 1, 'build versions differ');

--- a/apps/LiveTL/src/components/ExportActionButtons.svelte
+++ b/apps/LiveTL/src/components/ExportActionButtons.svelte
@@ -1,5 +1,5 @@
 <script>
-  import Tooltip from '../submodules/chat/src/components/common/Tooltip.svelte';
+  import Tooltip from '@hyperchat/components/common/Tooltip.svelte';
   import Button from './common/IconButton.svelte';
   import { createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher();

--- a/apps/LiveTL/src/components/MainPane.svelte
+++ b/apps/LiveTL/src/components/MainPane.svelte
@@ -1,7 +1,7 @@
 <script>
   import { afterUpdate, tick } from 'svelte';
   import { fade, fly } from 'svelte/transition';
-  import Tooltip from '../submodules/chat/src/components/common/Tooltip.svelte';
+  import Tooltip from '@hyperchat/components/common/Tooltip.svelte';
   import Wrapper from './Wrapper.svelte';
   import {
     TextDirection,
@@ -33,7 +33,7 @@
   import dark from 'smelte/src/dark';
   import Button from './common/IconButton.svelte';
   import { openLiveTL } from '../js/utils.js';
-  import { createPopup } from '../submodules/chat/src/ts/chat-utils';
+  import { createPopup } from '@hyperchat/ts/chat-utils';
 
   dark().set(true);
 

--- a/apps/LiveTL/src/components/Welcome.svelte
+++ b/apps/LiveTL/src/components/Welcome.svelte
@@ -19,19 +19,19 @@
 
   const questions = [{
     prompt: 'How does LiveTL work?',
-    response: `LiveTL is, at its core, 
+    response: `LiveTL is, at its core,
                a chat filter for YouTube streams.
                It helps foreign viewers better catch
-               translations that other viewers are 
-               providing in the live chat. LiveTL 
-               does not automatically translate streams 
-               – instead, it picks up translations 
+               translations that other viewers are
+               providing in the live chat. LiveTL
+               does not automatically translate streams
+               – instead, it picks up translations
                found in the chat.`
   }, {
     prompt: 'Can I trust LiveTL translations?',
     response: `LiveTL's translations are entirely crowdsourced,
                so there is no guarantee that they are accurate.
-               ALWAYS take caution when sharing translations 
+               ALWAYS take caution when sharing translations
                found in LiveTL.`
   }, {
     prompt: 'I installed LiveTL but I don’t see any buttons.',
@@ -39,9 +39,9 @@
               the YouTube stream for LiveTL to take effect.`
   }, {
     prompt: 'I don’t see any translations in the translations panel.',
-    response: `If there are no translators in chat, LiveTL is unable 
-               to provide translations. Any messages properly tagged 
-               with a language (ex. [en], ESP:, etc.) will appear when 
+    response: `If there are no translators in chat, LiveTL is unable
+               to provide translations. Any messages properly tagged
+               with a language (ex. [en], ESP:, etc.) will appear when
                they are available.`
   }, {
     prompt: 'A translator is using their own style of language tags.',
@@ -61,7 +61,7 @@
   </p>
 
   <img
-    src="https://raw.githubusercontent.com/LiveTL/LiveTL/main/img/buttons.png"
+    src="https://raw.githubusercontent.com/LiveTL/LiveTL/main/apps/LiveTL/img/buttons.png"
     alt="img"
     class="w-full md:w-3/4 lg:w-3/5 my-2"
   />

--- a/apps/LiveTL/src/components/changelog/Changelog.svelte
+++ b/apps/LiveTL/src/components/changelog/Changelog.svelte
@@ -1,6 +1,6 @@
 <script>
   import ExpandingCard from '../common/ExpandingCard.svelte';
-  import HCChangelogs from '../../submodules/chat/src/components/changelog/Changelog.svelte';
+  import HCChangelogs from '@hyperchat/components/changelog/Changelog.svelte';
 </script>
 
 <ExpandingCard title="New HyperChat features" icon="chat">

--- a/apps/LiveTL/src/components/common/Icon.svelte
+++ b/apps/LiveTL/src/components/common/Icon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Icon from '../../submodules/chat/src/components/common/Icon.svelte';
+  import Icon from '@hyperchat/components/common/Icon.svelte';
   export let block = true;
   export let small = false;
   export let xs = false;

--- a/apps/LiveTL/src/hyperchat/index.ts
+++ b/apps/LiveTL/src/hyperchat/index.ts
@@ -1,0 +1,1 @@
+import '@hyperchat/hyperchat';

--- a/apps/LiveTL/src/hyperchat/options.ts
+++ b/apps/LiveTL/src/hyperchat/options.ts
@@ -1,0 +1,1 @@
+import '@hyperchat/options';

--- a/apps/LiveTL/src/hyperchat/scripts/chat-injector.ts
+++ b/apps/LiveTL/src/hyperchat/scripts/chat-injector.ts
@@ -1,0 +1,1 @@
+import '@hyperchat/scripts/chat-injector';

--- a/apps/LiveTL/src/hyperchat/scripts/chat-interceptor.ts
+++ b/apps/LiveTL/src/hyperchat/scripts/chat-interceptor.ts
@@ -1,0 +1,1 @@
+import '@hyperchat/scripts/chat-interceptor';

--- a/apps/LiveTL/src/hyperchat/scripts/chat-metagetter.ts
+++ b/apps/LiveTL/src/hyperchat/scripts/chat-metagetter.ts
@@ -1,0 +1,1 @@
+import '@hyperchat/scripts/chat-metagetter';

--- a/apps/LiveTL/src/hyperchat/scripts/chat-mounter.ts
+++ b/apps/LiveTL/src/hyperchat/scripts/chat-mounter.ts
@@ -1,0 +1,1 @@
+import '@hyperchat/scripts/chat-mounter';

--- a/apps/LiveTL/src/hyperchat/scripts/chat-translation-host.ts
+++ b/apps/LiveTL/src/hyperchat/scripts/chat-translation-host.ts
@@ -1,0 +1,1 @@
+import '@hyperchat/scripts/chat-translation-host';

--- a/apps/LiveTL/src/hyperchat/stylesheets/page404.css
+++ b/apps/LiveTL/src/hyperchat/stylesheets/page404.css
@@ -1,0 +1,1 @@
+@import "../../../../HyperChat/src/stylesheets/page404.css";

--- a/apps/LiveTL/src/hyperchat/stylesheets/scrollbar.css
+++ b/apps/LiveTL/src/hyperchat/stylesheets/scrollbar.css
@@ -1,0 +1,1 @@
+@import "../../../../HyperChat/src/stylesheets/scrollbar.css";

--- a/apps/LiveTL/src/hyperchat/stylesheets/titlebar.css
+++ b/apps/LiveTL/src/hyperchat/stylesheets/titlebar.css
@@ -1,0 +1,1 @@
+@import "../../../../HyperChat/src/stylesheets/titlebar.css";

--- a/apps/LiveTL/src/js/pages/background.js
+++ b/apps/LiveTL/src/js/pages/background.js
@@ -1,5 +1,5 @@
 import './storage-promise-compat';
-import '../../submodules/chat/src/scripts/chat-background.ts';
+import '@hyperchat/scripts/chat-background';
 
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === 'install') { chrome.tabs.create({ url: chrome.runtime.getURL('welcome.html') }); }

--- a/apps/LiveTL/src/js/sources.js
+++ b/apps/LiveTL/src/js/sources.js
@@ -14,7 +14,7 @@ import { paramsYtVideoId, AuthorType, paramsPopout, paramsTabId, paramsFrameId, 
 import { twitchSource } from '../ts/sources';
 // import * as API from './api.js';
 import * as TLDEX from './tldex.js';
-import { useReconnect } from '../submodules/chat/src/ts/chat-utils.ts';
+import { useReconnect } from '@hyperchat/ts/chat-utils';
 
 /**
  * @typedef {import('svelte/store').Readable} Readable
@@ -228,7 +228,7 @@ export function ytcSource(_window) {
     return port;
   });
 
-  return { ytc, cleanUp: () => port && port.destroy() };
+  return { ytc, cleanUp: () => port.destroy() };
 }
 
 function message(author, msg, timestamp) {

--- a/apps/LiveTL/src/manifest.json
+++ b/apps/LiveTL/src/manifest.json
@@ -49,11 +49,11 @@
         "https://studio.youtube.com/live_chat_replay*"
       ],
       "js": [
-        "submodules/chat/src/scripts/chat-injector.ts",
+        "hyperchat/scripts/chat-injector.ts",
         "ts/content_scripts/injector.ts",
         "js/pages/translatormode.js"
       ],
-      "css": ["submodules/chat/src/stylesheets/titlebar.css"],
+      "css": ["hyperchat/stylesheets/titlebar.css"],
       "all_frames": true
     },
     {
@@ -70,10 +70,10 @@
   "{{mv3}}.content_scripts": [
     {
       "matches": ["https://www.youtube.com/embed/hyperchat_embed?*"],
-      "js": ["submodules/chat/src/scripts/chat-mounter.ts"],
+      "js": ["hyperchat/scripts/chat-mounter.ts"],
       "css": [
-        "submodules/chat/src/stylesheets/scrollbar.css",
-        "submodules/chat/src/stylesheets/page404.css"
+        "hyperchat/stylesheets/scrollbar.css",
+        "hyperchat/stylesheets/page404.css"
       ],
       "all_frames": true
     },
@@ -85,11 +85,11 @@
         "https://studio.youtube.com/live_chat_replay*"
       ],
       "js": [
-        "submodules/chat/src/scripts/chat-injector.ts",
+        "hyperchat/scripts/chat-injector.ts",
         "ts/content_scripts/injector.ts",
         "js/pages/translatormode.js"
       ],
-      "css": ["submodules/chat/src/stylesheets/titlebar.css"],
+      "css": ["hyperchat/stylesheets/titlebar.css"],
       "all_frames": true
     },
     {

--- a/apps/LiveTL/src/ts/content_scripts/injector.ts
+++ b/apps/LiveTL/src/ts/content_scripts/injector.ts
@@ -1,5 +1,5 @@
 import { mdiOpenInNew, mdiYoutubeTv, mdiIframeArray } from '@mdi/js';
-import { getFrameInfoAsync, createPopup, isValidFrameInfo } from '../../submodules/chat/src/ts/chat-utils';
+import { getFrameInfoAsync, createPopup, isValidFrameInfo } from '@hyperchat/ts/chat-utils';
 import { paramsEmbedDomain, AutoLaunchMode } from '../../js/constants.js';
 import { autoLaunchMode, holodexEnabled } from '../../js/store.js';
 import { constructParams, openLiveTL } from '../../js/utils.js';

--- a/apps/LiveTL/src/ts/content_scripts/twitch-injector.ts
+++ b/apps/LiveTL/src/ts/content_scripts/twitch-injector.ts
@@ -1,10 +1,10 @@
 import { isVod, parseMessageElement } from '../twitch-parser';
 import { nodeIsElement, injectLtlLauncher, ltlButtonParams } from '../utils';
-import { getFrameInfoAsync, createPopup, isValidFrameInfo } from '../../submodules/chat/src/ts/chat-utils';
+import { getFrameInfoAsync, createPopup, isValidFrameInfo } from '@hyperchat/ts/chat-utils';
 import { mdiOpenInNew, mdiIframeArray } from '@mdi/js';
 import { chatSize, twitchEnabled } from '../../js/store';
 import { get } from 'svelte/store';
-import type { Chat } from '../../submodules/chat/src/ts/typings/chat';
+import type { Chat } from '@hyperchat/ts/typings/chat';
 
 const liveChatSelector = '.chat-room .chat-scrollable-area__message-container';
 const vodChatSelector = '.video-chat .video-chat__message-list-wrapper ul';

--- a/apps/LiveTL/src/ts/sources.ts
+++ b/apps/LiveTL/src/ts/sources.ts
@@ -1,8 +1,8 @@
 import { writable, Writable } from 'svelte/store';
 import { paramsTabId, paramsFrameId } from '../js/constants';
 import { timestamp } from '../js/store';
-import { useReconnect } from '../submodules/chat/src/ts/chat-utils';
-import type { Chat } from '../submodules/chat/src/ts/typings/chat';
+import { useReconnect } from '@hyperchat/ts/chat-utils';
+import type { Chat } from '@hyperchat/ts/typings/chat';
 
 export function twitchSource(): Writable<Ltl.Message | null> {
   if (paramsTabId == null || paramsFrameId == null) return writable(null);

--- a/apps/LiveTL/src/ts/twitch-parser.ts
+++ b/apps/LiveTL/src/ts/twitch-parser.ts
@@ -134,7 +134,7 @@ export function parseMessageElement(message: Element): Ltl.Message | undefined {
     // console.debug({ fragment });
     const result = parseMessageFragment(fragment);
     if (result == null) return;
-    if (result.type !== 'emoji') text += result.text;
+    if (result.type !== 'emoji') text += String(result.text);
     messageArray.push(result);
   });
 

--- a/apps/LiveTL/tsconfig.json
+++ b/apps/LiveTL/tsconfig.json
@@ -4,14 +4,17 @@
     "outDir": "./build/",
     "noEmit": true,
     "baseUrl": "./src",
+    "paths": {
+      "@hyperchat/*": ["../../HyperChat/src/*"]
+    },
     "allowJs": true,
     "checkJs": false,
     "strict": true,
     "lib": ["DOM", "dom.iterable"],
     "target": "esnext",
     "resolveJsonModule": true,
-    "typeRoots": ["../../node_modules/@types", "./src/ts/typings", "./src/submodules/chat/src/ts/typings"]
+    "typeRoots": ["../../node_modules/@types", "./src/ts/typings"]
   },
-  "include": ["src/**/*", "*.js", "utils/**/*"],
+  "include": ["src/**/*", "../HyperChat/src/ts/typings/**/*.d.ts", "*.js", "utils/**/*"],
   "exclude": ["node_modules", "build", "**/vite.config.ts"]
 }

--- a/apps/LiveTL/vite.config.js
+++ b/apps/LiveTL/vite.config.js
@@ -5,9 +5,8 @@ import path from 'path';
 import fs from 'fs';
 import alias from '@rollup/plugin-alias';
 import copy from 'rollup-plugin-copy';
-import replace from 'rollup-plugin-replace';
 import manifest from './src/manifest.json';
-import { resolveMv } from './src/submodules/chat/scripts/resolve-manifest';
+import { resolveMv } from '../HyperChat/scripts/resolve-manifest';
 
 // include all entry points from src/js/pages/*.js
 const pagesEntryPoints = [
@@ -22,16 +21,16 @@ const entryPoints = [
     name: 'html/background.html',
     scripts: ['/js/pages/background.js']
   },
-  { name: 'html/hyperchat/index.html', scripts: ['/submodules/chat/src/hyperchat.ts'] },
-  { name: 'html/hyperchat/options.html', scripts: ['/submodules/chat/src/options.ts'] }
+  { name: 'html/hyperchat/index.html', scripts: ['/hyperchat/index.ts'] },
+  { name: 'html/hyperchat/options.html', scripts: ['/hyperchat/options.ts'] }
 ];
 
 const jsEntry = [
   'ts/yt-workaround.ts',
-  'submodules/chat/src/scripts/chat-interceptor.ts',
-  'submodules/chat/src/scripts/chat-metagetter.ts',
-  'submodules/chat/src/scripts/chat-mounter.ts',
-  'submodules/chat/src/scripts/chat-translation-host.ts'
+  'hyperchat/scripts/chat-interceptor.ts',
+  'hyperchat/scripts/chat-metagetter.ts',
+  'hyperchat/scripts/chat-mounter.ts',
+  'hyperchat/scripts/chat-translation-host.ts'
 ];
 
 const entryPointTemplate = fs.readFileSync(path.join(__dirname, 'src/empty.html'))
@@ -70,7 +69,8 @@ export default defineConfig({
   define: {
     __BROWSER__: JSON.stringify(browser),
     __VERSION__: JSON.stringify(version),
-    __MV__: JSON.stringify(mv)
+    __MV__: JSON.stringify(mv),
+    __LIVETL__: JSON.stringify(true)
   },
   build: {
     outDir: path.resolve(__dirname, buildDir),
@@ -84,17 +84,12 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@hyperchat': path.resolve(__dirname, '../HyperChat/src'),
       'jquery.ui': 'jquery-ui-bundle'
     }
   },
   plugins: [
     alias(),
-
-    replace({
-      values: {
-        'isLiveTL = false': 'isLiveTL = true'
-      }
-    }),
 
     // TODO: add the isAndroid replacements
     svelte({
@@ -126,7 +121,7 @@ export default defineConfig({
     copy({
       hook: 'writeBundle',
       targets: [{
-        src: path.resolve(__dirname, 'src/submodules/chat/src/assets/*'),
+        src: path.resolve(__dirname, '../HyperChat/src/assets/*'),
         dest: `${buildDir}/hyperchat`
       }]
     }),
@@ -148,8 +143,8 @@ export default defineConfig({
     copy({
       hook: 'writeBundle',
       targets: [{
-        src: path.resolve(__dirname, 'src/submodules/chat/src/stylesheets/*'),
-        dest: `${buildDir}/submodules/chat/src/stylesheets`
+        src: path.resolve(__dirname, '../HyperChat/src/stylesheets/*'),
+        dest: `${buildDir}/hyperchat/stylesheets`
       }]
     }),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,7 +1216,6 @@
         "postinstall-postinstall": "^2.1.0",
         "request": "2.88.2",
         "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-replace": "^2.2.0",
         "sass": "^1.32.8",
         "sha-1": "^1.0.0",
         "svelte": "3.49.0",
@@ -20710,28 +20709,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-replace": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
-      "integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
-      "deprecated": "This module has moved and is now available at @rollup/plugin-replace. Please update your dependencies. This version is no longer maintained.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.25.2",
-        "rollup-pluginutils": "^2.6.0"
-      }
-    },
-    "node_modules/rollup-plugin-replace/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/rollup-pluginutils": {


### PR DESCRIPTION
This makes the HyperChat repo redundant. This can still be further cleaned up to better pull out common stuff rather than doing some weird cross-app compilation, but this technically works.